### PR TITLE
Make command-line unit testing work without workarounds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Shell scripts must stay LF or they break when run.
+*.sh text eol=lf
+
+# Windows batch files must stay CRLF.
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,52 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'source/**'
+      - 'test/**'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    paths:
+      - 'source/**'
+      - 'test/**'
+      - '.github/workflows/tests.yml'
+  workflow_dispatch:
+
+jobs:
+  fpc:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout daraja-framework
+        uses: actions/checkout@v4
+        with:
+          path: daraja-framework
+
+      - name: Checkout Indy (dependency)
+        uses: actions/checkout@v4
+        with:
+          repository: IndySockets/Indy
+          path: Indy
+
+      - name: Checkout slf4p (dependency)
+        uses: actions/checkout@v4
+        with:
+          repository: michaelJustin/slf4p
+          path: slf4p
+
+      - name: Install Lazarus / FPC
+        uses: gcarreno/setup-lazarus@v3
+        with:
+          lazarus-version: stable
+
+      - name: Build the test runner (Console build mode)
+        working-directory: daraja-framework/test/unittests
+        run: lazbuild -B --build-mode=Console Unittests.lpi
+        shell: bash
+
+      - name: Run the test suite (headless)
+        working-directory: daraja-framework/test/unittests
+        run: ./UnittestsConsole.exe --all --format=plain
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,10 @@ test/unittests/dunit.ini
 test/unittests/Unittests.dbg
 test/unittests/ppas.bat
 
+# The test project file is tracked: it carries the dependency search paths
+# needed to build the suite from a clean checkout (see UNIT-TESTS.md).
+!test/unittests/Unittests.dproj
+
 client_secret.json
 
 DarajaFrameworkGettingStarted.pdf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# Daraja HTTP Framework
+
+Compact HTTP server application framework for Object Pascal. Targets **Delphi
+2009+** and **Lazarus 4.x / FPC 3.2.x**. Keep every change compiling on both.
+
+## Layout
+
+- `source/` — the framework. `source/optional/` holds unsupported helper units.
+- `test/unittests/` — the test suite (FPCUnit + DUnit). See `UNIT-TESTS.md`.
+- `demo/` — example servers.
+- API doc-comment conventions: see `DOC-COMMENTS.md`.
+
+## Dependencies
+
+Expected as **siblings of this repository directory**:
+
+- `Indy/Lib/{Core,Protocols,System}` — Indy 10.6.2 / 10.6.3 (use this checkout,
+  not the one bundled with Delphi — older bundled versions lack `hcPATCH`).
+- `slf4p/src/main` — Simple Logging Facade for Pascal.
+
+## Running the tests
+
+From `test/unittests/`:
+
+- FPC: `run-fpc.cmd` / `run-fpc.sh` (builds the `Console` build mode, runs headless)
+- Delphi: `run-delphi.cmd` (builds with `dcc32`, runs the DUnit text runner)
+
+Both exit non-zero on failure. Full details, including how to run a single suite
+and the GUI runners, are in `UNIT-TESTS.md`.

--- a/UNIT-TESTS.md
+++ b/UNIT-TESTS.md
@@ -5,8 +5,8 @@ files feeds two project files:
 
 | Project | Compiler | Runner |
 |---------|----------|--------|
-| `Unittests.lpi` | Free Pascal / Lazarus | FPCUnit (console or GUI) |
-| `Unittests.dpr` | Delphi | DUnit (text or GUI) |
+| `Unittests.lpi` | Free Pascal / Lazarus | FPCUnit |
+| `Unittests.dpr` | Delphi | DUnit |
 
 ## Dependencies
 
@@ -19,58 +19,93 @@ Both builds expect these checkouts as **siblings of the repository directory**
 For Delphi, use this Indy checkout, **not** the one bundled with the IDE — older
 bundled Indy versions lack `hcPATCH` and will not compile the framework.
 
-## Free Pascal / Lazarus
+## Quick start
+
+From `test/unittests/`:
 
 ```
-lazbuild -B test/unittests/Unittests.lpi
-cd test/unittests
-Unittests.exe --all --format=plain
+run-fpc.cmd          # Windows, Free Pascal / Lazarus
+./run-fpc.sh         # POSIX, Free Pascal / Lazarus
+run-delphi.cmd       # Windows, Delphi
 ```
 
-Any command-line argument selects the console runner; with no arguments the GUI
-runner opens.
+Each script builds from scratch, runs the **whole** suite headless, prints a
+plain-text report, and exits non-zero if anything failed. No IDE, no
+interaction, no environment setup beyond the dependencies above.
 
-Note: the `.lpi` sets `GraphicApplication=True`, so a run whose output is piped
-or redirected produces **no stdout**. To capture console output, temporarily set
-`<GraphicApplication Value="False"/>` in the `.lpi`, rebuild, then revert.
+- `run-fpc` needs `lazbuild` on `PATH`, or set `LAZBUILD` to its full path.
+- `run-delphi` defaults to RAD Studio 2009 at
+  `C:\Program Files (x86)\CodeGear\RAD Studio\6.0`; override `BDS` and `INDY` if
+  your layout differs.
 
-## Delphi
+Extra arguments are forwarded to the runner, e.g.
+`run-fpc.cmd --suite=TdjPathMapTests` or
+`run-fpc.cmd --format=xml --file=results.xml`.
 
-Build from the `test/unittests/` directory (adjust the two paths for your
-machine):
+## What the scripts do
+
+### Free Pascal
 
 ```
-set RS=C:\Program Files (x86)\CodeGear\RAD Studio\6.0
-set I=..\..\..\Indy\Lib
-"%RS%\bin\dcc32.exe" -B -Q ^
-  "-U%RS%\lib;%I%\Core;%I%\Protocols;%I%\System;..\..\source;..\..\source\optional;..\..\..\slf4p\src\main" ^
-  "-I%I%\Core;%I%\System" -N0<dcu-output-dir> -E. Unittests.dpr
+lazbuild -B --build-mode=Console Unittests.lpi
+UnittestsConsole.exe --all --format=plain
+```
+
+The project has two build modes:
+
+- **Default** — GUI test runner (`Unittests.exe`), for interactive use.
+- **Console** — console-subsystem binary (`UnittestsConsole.exe`) whose stdout
+  works under redirection and which never waits for input. This is the one used
+  for scripted / CI runs.
+
+Exit code: bit 0 set on failures, bit 1 set on errors.
+
+### Delphi
+
+```
+dcc32 -B -Q -U<...;Indy Lib;source;slf4p> -I<Indy Core;Indy System> -E. Unittests.dpr
 Unittests.exe -text-mode
 ```
 
-- `-I` (include search path) is required for `IdCompilerDefines.inc`.
-- `-E.` puts the exe in `test/unittests/` — see the working-directory note below.
-- Without `-text-mode` the DUnit GUI runner opens.
-- Two harmless Indy warnings are expected (W1036 `LCloseConnection`, W1035 SSPI).
+`Unittests.dpr` runs the DUnit **text** runner with `-text-mode` and the DUnit
+**GUI** runner otherwise. The text runner uses `rxbHaltOnFailures`, so the
+process exits with `ErrorCount + FailureCount`.
 
-## Running the full suite
+The `-I` include path is required for `IdCompilerDefines.inc`. Two harmless Indy
+warnings are expected (W1036 `LCloseConnection`, W1035 SSPI).
 
-`TestHelper.RegisterUnitTests` only registers the session, HTTPS and API-config
-suites when `not UseConsoleTestRunner` — i.e. when **no** command-line argument
-is passed. Every CLI invocation passes an argument, so the console / text runner
-sees only the small subset (~16–17 tests).
+## Running a subset
 
-To run the full suite from the command line, temporarily remove the
-`if not UseConsoleTestRunner` guard in `TestHelper.RegisterUnitTests` (there is
-one in the FPC branch and one in the `{$ELSE}` Delphi branch), rebuild, run, then
-revert. Alternatively, run the GUI runner, which always registers everything.
+- FPCUnit: `--suite=<TestCaseClass>` (optionally `.<TestMethod>`), or `--list`.
+- DUnit text runner: registered-test selection is not available on the command
+  line; use the GUI runner, or temporarily narrow `RegisterUnitTests`.
 
-Full suite size: **67 tests** (FPC) / **66 tests** (Delphi — the FPC-only
-`TdjWebFilterTests` is not in the Delphi project).
+## Optional / opt-out suites
 
-## Working directory
+- The **HTTPS** suite (`THttpsTests`) is compiled only when `DARAJA_TEST_HTTPS`
+  is defined (it needs the OpenSSL DLLs).
+- The integration suites that start a loopback HTTP server (`TSessionTests`,
+  `TAPIConfigTests`) run everywhere by default. Define `DARAJA_SKIP_SERVER_TESTS`
+  to exclude them on environments where binding a listening socket is not
+  possible.
 
-`TdjDefaultWebComponent` resolves the `webapps\` folder relative to
-`ExtractFilePath(ParamStr(0))` (the executable's location), not the current
-directory. The test executable must therefore sit in `test/unittests/` (next to
-`webapps/`), or `TdjDefaultWebComponentTests` will get 404 responses.
+## GUI runners
+
+Build the default mode (`lazbuild -B Unittests.lpi`, or the Delphi project
+without `-text-mode`) and run the executable with no arguments.
+
+## Continuous integration
+
+[`.github/workflows/tests.yml`](.github/workflows/tests.yml) checks out the two
+dependencies as siblings, installs Lazarus, and runs the Free Pascal suite
+headless on every push and pull request that touches `source/` or `test/`.
+
+## Notes
+
+- The runners `SetCurrentDir` to the executable's own folder at startup, so the
+  `.\resources\` paths used by the upload tests resolve regardless of where the
+  runner is launched from.
+- `TdjDefaultWebComponent` resolves `webapps\` relative to
+  `ExtractFilePath(ParamStr(0))`, so the test executable must be built into
+  `test/unittests/` (next to `webapps/`). All project files and scripts already
+  do this.

--- a/test/unittests/TestHelper.pas
+++ b/test/unittests/TestHelper.pas
@@ -85,14 +85,17 @@ begin
   // optional feature
   Tests.AddTest(TTestSuite.Create(TdjDefaultWebComponentTests));
 
-  if not UseConsoleTestRunner then
-  begin
-    Tests.AddTest(TTestSuite.Create(TSessionTests));
-    {$IFDEF DARAJA_TEST_HTTPS}
-    Tests.AddTest(TTestSuite.Create(THttpsTests));
-    {$ENDIF DARAJA_TEST_HTTPS}
-    Tests.AddTest(TTestSuite.Create(TAPIConfigTests));
-  end;
+  // Integration suites: these start a real HTTP server on the loopback
+  // interface. They run in every runner (console and GUI). Set the
+  // DARAJA_SKIP_SERVER_TESTS define to exclude them on environments where
+  // binding a listening socket is not possible.
+  {$IFNDEF DARAJA_SKIP_SERVER_TESTS}
+  Tests.AddTest(TTestSuite.Create(TSessionTests));
+  Tests.AddTest(TTestSuite.Create(TAPIConfigTests));
+  {$IFDEF DARAJA_TEST_HTTPS}
+  Tests.AddTest(TTestSuite.Create(THttpsTests));
+  {$ENDIF DARAJA_TEST_HTTPS}
+  {$ENDIF DARAJA_SKIP_SERVER_TESTS}
 
   RegisterTest('', Tests);
 end;
@@ -103,17 +106,21 @@ begin
   RegisterTests('', [TdjWebComponentHolderTests.Suite]);
   RegisterTests('', [TdjWebComponentHandlerTests.Suite]);
   RegisterTests('', [TdjWebAppContextTests.Suite]);
+  RegisterTests('', [TdjWebFilterTests.Suite]);
   // optional feature
   RegisterTests('', [TdjDefaultWebComponentTests.Suite]);
 
-  if not UseConsoleTestRunner then
-  begin
-    RegisterTests('', [TAPIConfigTests.Suite]);
-    {$IFDEF DARAJA_TEST_HTTPS}
-    RegisterTests('', [THttpsTests.Suite]);
-    {$ENDIF DARAJA_TEST_HTTPS}
-    RegisterTests('', [TSessionTests.Suite]);
-  end;
+  // Integration suites: these start a real HTTP server on the loopback
+  // interface. They run in every runner (text and GUI). Set the
+  // DARAJA_SKIP_SERVER_TESTS define to exclude them on environments where
+  // binding a listening socket is not possible.
+  {$IFNDEF DARAJA_SKIP_SERVER_TESTS}
+  RegisterTests('', [TSessionTests.Suite]);
+  RegisterTests('', [TAPIConfigTests.Suite]);
+  {$IFDEF DARAJA_TEST_HTTPS}
+  RegisterTests('', [THttpsTests.Suite]);
+  {$ENDIF DARAJA_TEST_HTTPS}
+  {$ENDIF DARAJA_SKIP_SERVER_TESTS}
 end;
 {$ENDIF}
 

--- a/test/unittests/Unittests.dpr
+++ b/test/unittests/Unittests.dpr
@@ -74,6 +74,7 @@ uses
   djWebAppContextTests in 'djWebAppContextTests.pas',
   djWebComponentHandlerTests in 'djWebComponentHandlerTests.pas',
   djWebComponentHolderTests in 'djWebComponentHolderTests.pas',
+  djWebFilterTests in 'djWebFilterTests.pas',
   HTTPTestCase in 'HTTPTestCase.pas',
   TestSessions in 'TestSessions.pas',
   UnicodeText in 'UnicodeText.pas',
@@ -89,12 +90,20 @@ uses
   djWebFilterMapping in '..\..\source\djWebFilterMapping.pas';
 
 begin
+  // The upload tests read and write .\resources\ relative to the working
+  // directory. Pin it to the executable location so the runner can be started
+  // from anywhere.
+  SetCurrentDir(ExtractFileDir(ParamStr(0)));
+
   ConfigureLogging;
 
   RegisterUnitTests;
 
   if FindCmdLineSwitch('text-mode', ['-', '/'], true) then
-    TextTestRunner.RunRegisteredTests(rxbContinue)
+    // rxbHaltOnFailures makes the process exit with a non-zero code
+    // (ErrorCount + FailureCount) when the run is red, so scripts and CI
+    // can detect failures.
+    TextTestRunner.RunRegisteredTests(rxbHaltOnFailures)
   else
   begin
     ReportMemoryLeaksOnShutDown := True;

--- a/test/unittests/Unittests.dproj
+++ b/test/unittests/Unittests.dproj
@@ -1,0 +1,159 @@
+﻿	<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+		<PropertyGroup>
+			<ProjectGuid>{05F27375-5B7B-4A86-B43B-18B10F75A56C}</ProjectGuid>
+			<MainSource>Unittests.dpr</MainSource>
+			<Config Condition="'$(Config)'==''">Debug</Config>
+			<DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
+			<ProjectVersion>12.0</ProjectVersion>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+			<Base>true</Base>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+			<Cfg_1>true</Cfg_1>
+			<CfgParent>Base</CfgParent>
+			<Base>true</Base>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+			<Cfg_2>true</Cfg_2>
+			<CfgParent>Base</CfgParent>
+			<Base>true</Base>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Base)'!=''">
+			<DCC_Define>DARAJA_LOGGING;$(DCC_Define)</DCC_Define>
+			<DCC_UnitSearchPath>..\..\source;..\..\source\optional;..\..\..\slf4p\src\main;..\..\..\Indy\Lib\Core;..\..\..\Indy\Lib\Protocols;..\..\..\Indy\Lib\System;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+			<DCC_IncludePath>..\..\..\Indy\Lib\Core;..\..\..\Indy\Lib\System;$(DCC_IncludePath)</DCC_IncludePath>
+			<DCC_DependencyCheckOutputName>Unittests.exe</DCC_DependencyCheckOutputName>
+			<DCC_ImageBase>00400000</DCC_ImageBase>
+			<DCC_K>false</DCC_K>
+			<DCC_F>false</DCC_F>
+			<DCC_Platform>x86</DCC_Platform>
+			<DCC_N>false</DCC_N>
+			<DCC_S>false</DCC_S>
+			<DCC_E>false</DCC_E>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Cfg_1)'!=''">
+			<DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+			<DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+			<DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+			<DCC_DebugInformation>false</DCC_DebugInformation>
+		</PropertyGroup>
+		<PropertyGroup Condition="'$(Cfg_2)'!=''">
+			<DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+		</PropertyGroup>
+		<ItemGroup>
+			<DelphiCompile Include="Unittests.dpr">
+				<MainSource>MainSource</MainSource>
+			</DelphiCompile>
+			<DCCReference Include="..\..\source\djAbstractConfig.pas"/>
+			<DCCReference Include="..\..\source\djAbstractConnector.pas"/>
+			<DCCReference Include="..\..\source\djAbstractHandler.pas"/>
+			<DCCReference Include="..\..\source\djAbstractHandlerContainer.pas"/>
+			<DCCReference Include="..\..\source\djContextConfig.pas"/>
+			<DCCReference Include="..\..\source\djContextHandler.pas"/>
+			<DCCReference Include="..\..\source\djContextHandlerCollection.pas"/>
+			<DCCReference Include="..\..\source\optional\djDefaultHandler.pas"/>
+			<DCCReference Include="..\..\source\optional\djDefaultWebComponent.pas"/>
+			<DCCReference Include="..\..\source\djGenericHolder.pas"/>
+			<DCCReference Include="..\..\source\djGenericWebComponent.pas"/>
+			<DCCReference Include="..\..\source\djGenericWebFilter.pas"/>
+			<DCCReference Include="..\..\source\djGlobal.pas"/>
+			<DCCReference Include="..\..\source\djHandlerCollection.pas"/>
+			<DCCReference Include="..\..\source\djHandlerList.pas"/>
+			<DCCReference Include="..\..\source\djHandlerWrapper.pas"/>
+			<DCCReference Include="..\..\source\djHTTPConnector.pas"/>
+			<DCCReference Include="..\..\source\djHTTPConstants.pas"/>
+			<DCCReference Include="..\..\source\djHTTPServer.pas"/>
+			<DCCReference Include="..\..\source\djInitParameters.pas"/>
+			<DCCReference Include="..\..\source\djInterfaces.pas"/>
+			<DCCReference Include="..\..\source\djLifeCycle.pas"/>
+			<DCCReference Include="..\..\source\djPathMap.pas"/>
+			<DCCReference Include="..\..\source\djPlatform.pas"/>
+			<DCCReference Include="..\..\source\djServer.pas"/>
+			<DCCReference Include="..\..\source\djServerBase.pas"/>
+			<DCCReference Include="..\..\source\djServerContext.pas"/>
+			<DCCReference Include="..\..\source\djServerInterfaces.pas"/>
+			<DCCReference Include="..\..\source\optional\djStacktrace.pas"/>
+			<DCCReference Include="..\..\source\djTypes.pas"/>
+			<DCCReference Include="..\..\source\djWebAppContext.pas"/>
+			<DCCReference Include="..\..\source\djWebComponent.pas"/>
+			<DCCReference Include="..\..\source\djWebComponentConfig.pas"/>
+			<DCCReference Include="..\..\source\djWebComponentContextHandler.pas"/>
+			<DCCReference Include="..\..\source\djWebComponentHandler.pas"/>
+			<DCCReference Include="..\..\source\djWebComponentHolder.pas"/>
+			<DCCReference Include="..\..\source\djWebComponentHolders.pas"/>
+			<DCCReference Include="..\..\source\djWebComponentMapping.pas"/>
+			<DCCReference Include="ConfigAPITests.pas"/>
+			<DCCReference Include="HttpsTests.pas"/>
+			<DCCReference Include="djDefaultWebComponentTests.pas"/>
+			<DCCReference Include="djPathMapTests.pas"/>
+			<DCCReference Include="djWebAppContextTests.pas"/>
+			<DCCReference Include="djWebComponentHandlerTests.pas"/>
+			<DCCReference Include="djWebComponentHolderTests.pas"/>
+			<DCCReference Include="HTTPTestCase.pas"/>
+			<DCCReference Include="TestSessions.pas"/>
+			<DCCReference Include="UnicodeText.pas"/>
+			<DCCReference Include="TestHelper.pas"/>
+			<DCCReference Include="..\..\source\djWebFilter.pas"/>
+			<DCCReference Include="..\..\source\djWebFilterChain.pas"/>
+			<DCCReference Include="..\..\source\djWebFilterConfig.pas"/>
+			<DCCReference Include="..\..\source\djWebFilterHolder.pas"/>
+			<DCCReference Include="..\..\source\djWebFilterMapping.pas"/>
+			<BuildConfiguration Include="Base">
+				<Key>Base</Key>
+			</BuildConfiguration>
+			<BuildConfiguration Include="Release">
+				<Key>Cfg_1</Key>
+				<CfgParent>Base</CfgParent>
+			</BuildConfiguration>
+			<BuildConfiguration Include="Debug">
+				<Key>Cfg_2</Key>
+				<CfgParent>Base</CfgParent>
+			</BuildConfiguration>
+		</ItemGroup>
+		<Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+		<ProjectExtensions>
+			<Borland.Personality>Delphi.Personality.12</Borland.Personality>
+			<Borland.ProjectType>VCLApplication</Borland.ProjectType>
+			<BorlandProject>
+				<Delphi.Personality>
+					<Source>
+						<Source Name="MainSource">Unittests.dpr</Source>
+					</Source>
+					<Parameters>
+						<Parameters Name="UseLauncher">False</Parameters>
+						<Parameters Name="LoadAllSymbols">True</Parameters>
+						<Parameters Name="LoadUnspecifiedSymbols">False</Parameters>
+					</Parameters>
+					<VersionInfo>
+						<VersionInfo Name="IncludeVerInfo">False</VersionInfo>
+						<VersionInfo Name="AutoIncBuild">False</VersionInfo>
+						<VersionInfo Name="MajorVer">1</VersionInfo>
+						<VersionInfo Name="MinorVer">0</VersionInfo>
+						<VersionInfo Name="Release">0</VersionInfo>
+						<VersionInfo Name="Build">0</VersionInfo>
+						<VersionInfo Name="Debug">False</VersionInfo>
+						<VersionInfo Name="PreRelease">False</VersionInfo>
+						<VersionInfo Name="Special">False</VersionInfo>
+						<VersionInfo Name="Private">False</VersionInfo>
+						<VersionInfo Name="DLL">False</VersionInfo>
+						<VersionInfo Name="Locale">1031</VersionInfo>
+						<VersionInfo Name="CodePage">1252</VersionInfo>
+					</VersionInfo>
+					<VersionInfoKeys>
+						<VersionInfoKeys Name="CompanyName"/>
+						<VersionInfoKeys Name="FileDescription"/>
+						<VersionInfoKeys Name="FileVersion">1.0.0.0</VersionInfoKeys>
+						<VersionInfoKeys Name="InternalName"/>
+						<VersionInfoKeys Name="LegalCopyright"/>
+						<VersionInfoKeys Name="LegalTrademarks"/>
+						<VersionInfoKeys Name="OriginalFilename"/>
+						<VersionInfoKeys Name="ProductName"/>
+						<VersionInfoKeys Name="ProductVersion">1.0.0.0</VersionInfoKeys>
+						<VersionInfoKeys Name="Comments"/>
+					</VersionInfoKeys>
+				</Delphi.Personality>
+			</BorlandProject>
+			<ProjectFileVersion>12</ProjectFileVersion>
+		</ProjectExtensions>
+	</Project>

--- a/test/unittests/Unittests.lpi
+++ b/test/unittests/Unittests.lpi
@@ -15,8 +15,42 @@
     <i18n>
       <EnableI18N LFM="False"/>
     </i18n>
-    <BuildModes Count="1">
+    <BuildModes Count="2">
       <Item1 Name="Default" Default="True"/>
+      <Item2 Name="Console">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value=".\UnittestsConsole.exe"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir);..\..\..\Indy\Lib\Core"/>
+            <OtherUnitFiles Value="..\..\source;..\..\source\optional;..\..\..\Indy\Lib\Core;..\..\..\Indy\Lib\Protocols;..\..\..\Indy\Lib\System;..\..\..\slf4p\src\main"/>
+            <UnitOutputDirectory Value="lib\console\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Parsing>
+            <SyntaxOptions>
+              <SyntaxMode Value="Delphi"/>
+            </SyntaxOptions>
+          </Parsing>
+          <Linking>
+            <Debugging>
+              <DebugInfoType Value="dsDwarf3"/>
+            </Debugging>
+            <Options>
+              <Win32>
+                <GraphicApplication Value="False"/>
+              </Win32>
+            </Options>
+          </Linking>
+          <Other>
+            <CompilerMessages>
+              <IgnoredMessages idx6058="True" idx5093="True" idx5091="True" idx5071="True" idx5062="True" idx5024="True" idx4046="True" idx3124="True" idx3123="True"/>
+            </CompilerMessages>
+          </Other>
+        </CompilerOptions>
+      </Item2>
     </BuildModes>
     <PublishOptions>
       <Version Value="2"/>

--- a/test/unittests/Unittests.lpr
+++ b/test/unittests/Unittests.lpr
@@ -31,6 +31,7 @@ uses
 {$IFDEF LINUX}
   cthreads,
 {$ENDIF}
+  SysUtils,
   LazUTF8,
   djLogAPI, djLogOverSimpleLogger, SimpleLogger,
   Forms,
@@ -41,6 +42,7 @@ uses
   djWebComponentHolderTests,
   djWebComponentHandlerTests,
   djDefaultWebComponentTests,
+  djWebFilterTests,
   ConfigAPITests,
   HttpsTests,
   TestHelper,
@@ -57,6 +59,11 @@ begin
   GIdIconvUseTransliteration := True;
   {$ENDIF}
 
+  // The upload tests read and write .\resources\ relative to the working
+  // directory. Pin it to the executable location (which is test\unittests\,
+  // next to resources\ and webapps\) so the runner can be started from anywhere.
+  SetCurrentDir(ExtractFileDir(ParamStr(0)));
+
   ConfigureLogging;
 
   RegisterUnitTests;
@@ -64,11 +71,9 @@ begin
   if UseConsoleTestRunner then
   begin
     // Launch console Test Runner --------------------------------------------
+    // Exit code: bit 0 set on failures, bit 1 set on errors (see FPCUnit
+    // TProgressWriter.GetExitCode), so scripts and CI can detect a red run.
     consoletestrunner.TTestRunner.Create(nil).Run;
-
-    {$IFNDEF LINUX}
-    ReadLn;
-    {$ENDIF}
   end else begin
     // Launch GUI Test Runner ------------------------------------------------
     Application.Initialize;

--- a/test/unittests/consoletests.cmd
+++ b/test/unittests/consoletests.cmd
@@ -1,3 +1,5 @@
-Unittests --all --format=plain
-
-pause
+@echo off
+rem Legacy entry point - kept for convenience. Prefer run-fpc.cmd, which also
+rem builds the Console build mode first.
+UnittestsConsole.exe --all --format=plain
+exit /b %ERRORLEVEL%

--- a/test/unittests/run-delphi.cmd
+++ b/test/unittests/run-delphi.cmd
@@ -1,0 +1,27 @@
+@echo off
+rem Build and run the unit tests with Delphi (dcc32), headless (DUnit text runner).
+rem
+rem   run-delphi.cmd            runs the whole suite
+rem   run-delphi.cmd -text-mode extra switches are forwarded to the runner
+rem
+rem Override these if your installation differs:
+rem   BDS   - RAD Studio / Delphi root (contains bin\dcc32.exe and lib\)
+rem   INDY  - Indy "Lib" directory (Core, Protocols, System)
+setlocal
+if "%BDS%"=="" set "BDS=C:\Program Files (x86)\CodeGear\RAD Studio\6.0"
+if "%INDY%"=="" set "INDY=%~dp0..\..\..\Indy\Lib"
+
+set "DCU=%~dp0lib\delphi"
+if not exist "%DCU%" mkdir "%DCU%"
+
+"%BDS%\bin\dcc32.exe" -B -Q ^
+  "-U%BDS%\lib;%INDY%\Core;%INDY%\Protocols;%INDY%\System;%~dp0..\..\source;%~dp0..\..\source\optional;%~dp0..\..\..\slf4p\src\main" ^
+  "-I%INDY%\Core;%INDY%\System" ^
+  "-N0%DCU%" "-E%~dp0." "%~dp0Unittests.dpr"
+if errorlevel 1 exit /b 1
+
+set ARGS=%*
+if "%ARGS%"=="" set ARGS=-text-mode
+
+"%~dp0Unittests.exe" %ARGS%
+exit /b %ERRORLEVEL%

--- a/test/unittests/run-fpc.cmd
+++ b/test/unittests/run-fpc.cmd
@@ -1,0 +1,18 @@
+@echo off
+rem Build and run the unit tests with Free Pascal / Lazarus, headless.
+rem
+rem   run-fpc.cmd                     runs the whole suite, plain text output
+rem   run-fpc.cmd --format=xml --file=results.xml   custom FPCUnit options
+rem
+rem Set LAZBUILD to your lazbuild.exe if it is not on PATH.
+setlocal
+if "%LAZBUILD%"=="" set LAZBUILD=lazbuild
+
+"%LAZBUILD%" -B --build-mode=Console "%~dp0Unittests.lpi"
+if errorlevel 1 exit /b 1
+
+set ARGS=%*
+if "%ARGS%"=="" set ARGS=--all --format=plain
+
+"%~dp0UnittestsConsole.exe" %ARGS%
+exit /b %ERRORLEVEL%

--- a/test/unittests/run-fpc.sh
+++ b/test/unittests/run-fpc.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Build and run the unit tests with Free Pascal / Lazarus, headless.
+#
+#   ./run-fpc.sh                                  whole suite, plain text output
+#   ./run-fpc.sh --format=xml --file=results.xml  custom FPCUnit options
+#
+# Set LAZBUILD to your lazbuild binary if it is not on PATH.
+set -e
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+"${LAZBUILD:-lazbuild}" -B --build-mode=Console "$here/Unittests.lpi"
+
+exe="$here/UnittestsConsole"
+[ -f "$exe.exe" ] && exe="$exe.exe"
+
+if [ "$#" -eq 0 ]; then
+  exec "$exe" --all --format=plain
+fi
+exec "$exe" "$@"


### PR DESCRIPTION
Fixes #413.

Running the unit tests from the command line now takes a single command and runs the whole suite. Verified on this machine: **FPC 67/67**, **Delphi 67/67**, exit code 0; a failing run exits non-zero.

## Quick start (from `test/unittests/`)

```
run-fpc.cmd        # Windows, Free Pascal / Lazarus
./run-fpc.sh       # POSIX, Free Pascal / Lazarus
run-delphi.cmd     # Windows, Delphi
```

Each builds from scratch, runs headless, prints a plain-text report and exits non-zero on failure. Extra arguments are forwarded (`--suite=`, `--format=xml --file=`, ...).

## Changes

### Test registration
- `TestHelper.RegisterUnitTests` no longer hides `TSessionTests` / `TAPIConfigTests` / `THttpsTests` from the console/text runner. All suites run in every runner.
- Environment-dependent suites are gated by defines instead: `DARAJA_TEST_HTTPS` (opt in, needs OpenSSL), new `DARAJA_SKIP_SERVER_TESTS` (opt out of the loopback-server suites).
- `djWebFilterTests` added to the Delphi project (was FPC-only).

### Free Pascal
- New **Console** build mode in `Unittests.lpi` → `UnittestsConsole.exe`, console subsystem, stdout works under redirection. The default (GUI) build mode is unchanged.
- `Unittests.lpr`: removed the `ReadLn` that blocked automation; `SetCurrentDir` to the executable folder at startup.
- FPCUnit already sets a correct exit code (bit 0 = failures, bit 1 = errors).

### Delphi
- `Unittests.dpr`: `TextTestRunner.RunRegisteredTests(rxbContinue)` → `rxbHaltOnFailures`, so a red run exits with `ErrorCount + FailureCount`. Same `SetCurrentDir`.
- `Unittests.dproj`: Indy and slf4p added to `DCC_UnitSearchPath` / `DCC_IncludePath` so a clean checkout builds without IDE library-path configuration. The file is now tracked (gitignore exception) because it carries those paths.

### Tooling
- `run-fpc.cmd`, `run-fpc.sh`, `run-delphi.cmd` — build + run wrappers.
- `.github/workflows/tests.yml` — checks out Indy + slf4p as siblings, installs Lazarus, runs the FPC suite on every push and PR that touches `source/` or `test/`.
- `.gitattributes` — keeps `*.sh` LF and `*.cmd` / `*.bat` CRLF.
- `UNIT-TESTS.md` rewritten around the scripts; new repo-root `CLAUDE.md`.

## Notes
- No source (`source/`) changes — test infrastructure only.
- `webapps\` is still resolved relative to the executable, so the runner executables are built into `test/unittests/`; all project files and scripts already do this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)