### PR TITLE
Minor fixes for a patch release

### DIFF
--- a/source/djAbstractConfig.pas
+++ b/source/djAbstractConfig.pas
@@ -54,14 +54,20 @@ type
      * The context.
      *}
     FContext: IContext;
+    {*
+     * The configuration name (e.g. the filter name).
+     *}
+    FName: string;
   protected
     // IWriteableConfig interface
     procedure Add(const Key: string; const Value: string);
     procedure SetContext(const Context: IContext);
+    procedure SetName(const AName: string);
   protected
     // IContextConfig interface todo more generic.
     function GetInitParameter(const Key: string): string;
     function GetInitParameterNames: TdjStrings;
+    function GetName: string;
   public
     {*
      * Constructor.
@@ -131,6 +137,16 @@ begin
   begin
     Result.Add(S);
   end;
+end;
+
+function TdjAbstractConfig.GetName: string;
+begin
+  Result := FName;
+end;
+
+procedure TdjAbstractConfig.SetName(const AName: string);
+begin
+  FName := AName;
 end;
 
 procedure TdjAbstractConfig.SetContext(const Context: IContext);

--- a/source/djContextHandler.pas
+++ b/source/djContextHandler.pas
@@ -70,6 +70,7 @@ type
     // IWriteableConfig interface
     procedure Add(const Key: string; const Value: string);
     procedure SetContext(const Context: IContext);
+    procedure SetName(const AName: string);
   protected
     // IContext interface
     procedure Init(const Config: IContextConfig);
@@ -260,6 +261,11 @@ end;
 procedure TdjContext.SetContext(const Context: IContext);
 begin
   // do nothing, we are in the context
+end;
+
+procedure TdjContext.SetName(const AName: string);
+begin
+  // do nothing, a context has no filter name
 end;
 
 procedure TdjContext.Log(const Msg: string);

--- a/source/djInterfaces.pas
+++ b/source/djInterfaces.pas
@@ -348,6 +348,12 @@ type
      * @throws EWebComponentException if the context is nil or if the context is already set and differs from the new context.
      *}
     procedure SetContext(const Context: IContext);
+
+    {*
+     * Sets the name reported by IWebFilterConfig.GetFilterName.
+     * @param AName the filter name
+     *}
+    procedure SetName(const AName: string);
   end;
 
   /// \cond

--- a/source/djPathMap.pas
+++ b/source/djPathMap.pas
@@ -122,6 +122,10 @@ procedure TdjPathMap.AddUrlPattern(const UrlPattern: string; Value: TObject);
 begin
   CheckExists(UrlPattern);
 
+  // keep entries in ascending order so GetMatches can return the
+  // longest (most specific) match first
+  Sorted := True;
+
   AddObject(UrlPattern, Value);
 end;
 
@@ -277,8 +281,6 @@ function TdjPathMap.GetMatches(const Path: string): TStrings;
   end;
 
 begin
-  Self.Sorted := True; // ascending order to have longest matches first
-
   Result := TStringList.Create;
 
   {

--- a/source/djWebComponentHolder.pas
+++ b/source/djWebComponentHolder.pas
@@ -213,6 +213,7 @@ begin
   // Trace('Destroy instance of ' + FClass.ClassName);
   try
     WebComponent.Free;
+    FWebComponent := nil;
   except
     on E: Exception do
     begin

--- a/source/djWebFilterConfig.pas
+++ b/source/djWebFilterConfig.pas
@@ -53,7 +53,7 @@ implementation
 
 function TdjWebFilterConfig.GetFilterName: string;
 begin
-  Result := ''; // TODO
+  Result := GetName;
 end;
 
 end.

--- a/source/djWebFilterHolder.pas
+++ b/source/djWebFilterHolder.pas
@@ -201,6 +201,7 @@ begin
       {$ENDIF DARAJA_LOGGING}
 
       WebFilter.Free;
+      FWebFilter := nil;
       raise;
     end;
   end;
@@ -223,6 +224,7 @@ begin
     end;
 
     WebFilter.Free;
+    FWebFilter := nil;
   except
     on E: Exception do
     begin

--- a/source/djWebFilterHolder.pas
+++ b/source/djWebFilterHolder.pas
@@ -178,6 +178,8 @@ begin
   Logger.Trace('Create instance of class ' + FClass.ClassName);
   {$ENDIF DARAJA_LOGGING}
 
+  (FConfig as IWriteableConfig).SetName(Name);
+
   FWebFilter := FClass.Create;
 
   try

--- a/source/optional/djNCSALogFilter.pas
+++ b/source/optional/djNCSALogFilter.pas
@@ -81,7 +81,8 @@ begin
   Result := FormatDateTime('dd/mmm/yyyy:hh:nn:ss', AValue, AFS);
 
   AOffset := OffsetFromUTC;
-  DecodeTime(AOffset, AHour, AMin, ASec, AMSec);
+  // DecodeTime does not handle a negative TDateTime, so decode the magnitude
+  DecodeTime(Abs(AOffset), AHour, AMin, ASec, AMSec);
 
   Bias := MinsPerHour * AHour + AMin;
 

--- a/source/optional/djStatisticsFilter.pas
+++ b/source/optional/djStatisticsFilter.pas
@@ -56,7 +56,7 @@ type
     FRequests: TIdThreadSafeInt64;
 
     function GetRequests: Int64;
-    function GetRequestsActive: Integer;
+    function GetRequestsActive: Int64;
     function GetResponses1xx: Int64;
     function GetResponses2xx: Int64;
     function GetResponses3xx: Int64;
@@ -70,7 +70,7 @@ type
       TdjResponse; const Chain: IWebFilterChain); override;
 
     property Requests: Int64 read GetRequests;
-    property RequestsActive: Integer read GetRequestsActive;
+    property RequestsActive: Int64 read GetRequestsActive;
     property Responses1xx: Int64 read GetResponses1xx;
     property Responses2xx: Int64 read GetResponses2xx;
     property Responses3xx: Int64 read GetResponses3xx;
@@ -120,7 +120,7 @@ begin
   Result := FRequests.Value;
 end;
 
-function TdjStatisticsFilter.GetRequestsActive: Integer;
+function TdjStatisticsFilter.GetRequestsActive: Int64;
 begin
   Result := FRequestsActive.Value;
 end;

--- a/test/unittests/ConfigAPITests.pas
+++ b/test/unittests/ConfigAPITests.pas
@@ -115,6 +115,7 @@ type
     procedure TestFilterWithInit;
     procedure TestFilterV3WithInit;
     procedure TestFilterInitCanReadContextConfiguration;
+    procedure TestFilterInitCanReadFilterName;
     //procedure TestOneFilterAndTwoWebComponents;
 
     procedure TestMapFilterTwiceToSameWebComponentRaisesException;
@@ -1121,6 +1122,17 @@ type
       Response: TdjResponse; const Chain: IWebFilterChain); override;
   end;
 
+  { TFilterReadsFilterName }
+
+  TFilterReadsFilterName = class(TdjWebFilter)
+  strict private
+    FFilterName: string;
+  public
+    procedure Init(const Config: IWebFilterConfig); override;
+    procedure DoFilter(Context: TdjServerContext; Request: TdjRequest;
+      Response: TdjResponse; const Chain: IWebFilterChain); override;
+  end;
+
   { TTestFilterA }
 
   TTestFilterA = class(TdjWebFilter)
@@ -1152,6 +1164,20 @@ procedure TFilterWithInitReadsContextConfiguration.DoFilter(
 begin
   Chain.DoFilter(Context, Request, Response);
   Response.ContentText := StaticContent;
+end;
+
+{ TFilterReadsFilterName }
+
+procedure TFilterReadsFilterName.Init(const Config: IWebFilterConfig);
+begin
+  FFilterName := Config.GetFilterName;
+end;
+
+procedure TFilterReadsFilterName.DoFilter(Context: TdjServerContext;
+  Request: TdjRequest; Response: TdjResponse; const Chain: IWebFilterChain);
+begin
+  Chain.DoFilter(Context, Request, Response);
+  Response.ContentText := 'filter name=' + FFilterName;
 end;
 
 { TTestFilter }
@@ -1399,6 +1425,27 @@ begin
     Server.Add(Context);
     Server.Start;
     CheckGETResponseEquals('from init 1 2 3', '/web/page.filter');
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TAPIConfigTests.TestFilterInitCanReadFilterName;
+var
+  Server: TdjServer;
+  Context: TdjWebAppContext;
+begin
+  // configure
+  Context := TdjWebAppContext.Create('web');
+  Context.Add(TExamplePage, '*.filter');
+  Context.Add(TFilterReadsFilterName, '*.filter');
+
+  // run
+  Server := TdjServer.Create;
+  try
+    Server.Add(Context);
+    Server.Start;
+    CheckGETResponseEquals('filter name=TFilterReadsFilterName', '/web/page.filter');
   finally
     Server.Free;
   end;


### PR DESCRIPTION
Small, self-contained fixes found while scanning `source/` for patch-sized issues. FPC (FPCUnit) and Delphi (DUnit) suites pass — 68 tests each.

## 1. Implement `IWebFilterConfig.GetFilterName`
`GetFilterName` was a stub returning `''`, so a web filter could not read its own name from the config passed to `Init`. Added `SetName` to `IWriteableConfig`, stored the value in `TdjAbstractConfig`, and had `TdjWebFilterHolder.DoStart` push its `Name` into the config before `Init`. `TdjContext` gets a no-op implementation. New regression test `TestFilterInitCanReadFilterName`.

## 2. Clear holder instance fields after freeing
`TdjWebFilterHolder` and `TdjWebComponentHolder` freed the held instance in `DoStop` (and, for the filter, on a failed init) but left the field pointing at the freed object. The field is now nilled so a later read or a repeated stop cannot dereference freed memory.

## 3. Sort `TdjPathMap` when patterns are added, not on lookup
`GetMatches` set `Sorted := True` as a side effect on every call. The sort order is now established in `AddUrlPattern`, so the query method no longer mutates the map.

## 4. djNCSALogFilter timezone suffix for negative UTC offsets (#416)
`DecodeTime` does not decode a negative `TDateTime`, so for zones west of UTC the numeric timezone suffix in the log line could be wrong. Decode the magnitude of the offset instead.

## 5. Widen `djStatisticsFilter.RequestsActive` to `Int64` (#417)
`GetRequestsActive` and the `RequestsActive` property were `Integer` while the backing `TIdThreadSafeInt64` and every sibling accessor are `Int64`, causing a silent 64->32 bit narrowing.

## Not included
The web-component-vs-web-filter difference in init-failure handling (component swallows and returns 405, filter propagates) was left as-is: it is deliberate graceful degradation and is pinned by `TestExceptionInComponentInitWithWebFilter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)