### PR TITLE
Release 3.1.2

### DIFF
--- a/source/djGlobal.pas
+++ b/source/djGlobal.pas
@@ -31,7 +31,7 @@ unit djGlobal;
 interface
 
 const
-  DWF_SERVER_VERSION = '3.1.2-SNAPSHOT';
+  DWF_SERVER_VERSION = '3.1.2';
   DWF_SERVER_FULL_NAME = 'Daraja HTTP Framework ' + DWF_SERVER_VERSION;
   DWF_SERVER_COPYRIGHT = 'Copyright (c) Michael Justin';
 


### PR DESCRIPTION
Drops the `-SNAPSHOT` suffix from `DWF_SERVER_VERSION` for the 3.1.2 release.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)