### PR TITLE
Enable heap tracing for the FPC test suite

### DIFF
--- a/UNIT-TESTS.md
+++ b/UNIT-TESTS.md
@@ -60,6 +60,21 @@ The project has two build modes:
 
 Exit code: bit 0 set on failures, bit 1 set on errors.
 
+#### Always check `heaptrace.log`
+
+The **Console** build mode is compiled with heap tracing (`-gh`), and the runner
+calls `SetHeapTraceOutput('heaptrace.log')`, so every `run-fpc` run rewrites
+`test/unittests/heaptrace.log` with the FPC leak report.
+
+A green test run is **not** enough — also open `heaptrace.log` and confirm the
+`unfreed memory blocks` count has not grown. A handful of blocks allocated from
+Indy unit initialisation (`IdThread`/`IdStack` `..._init$` frames) are expected
+and can be ignored; any block whose call trace points into `source/` or a test
+unit is a regression and must be fixed before merging.
+
+The heap report does not affect the process exit code, so scripts and CI that
+only check the exit status will miss leaks.
+
 ### Delphi
 
 ```

--- a/test/unittests/Unittests.lpi
+++ b/test/unittests/Unittests.lpi
@@ -37,6 +37,7 @@
           <Linking>
             <Debugging>
               <DebugInfoType Value="dsDwarf3"/>
+              <UseHeaptrc Value="True"/>
             </Debugging>
             <Options>
               <Win32>

--- a/test/unittests/Unittests.lpr
+++ b/test/unittests/Unittests.lpr
@@ -55,6 +55,13 @@ uses
 {$R *.res}
 
 begin
+  // When built with heap trace (Console build mode, -gh), write the leak
+  // report to heaptrace.log next to the executable. Must run before any
+  // allocation. See UNIT-TESTS.md.
+  {$IF DECLARED(SetHeapTraceOutput)}
+  SetHeapTraceOutput('heaptrace.log');
+  {$ENDIF}
+
   {$IFDEF LINUX}
   GIdIconvUseTransliteration := True;
   {$ENDIF}
@@ -81,8 +88,4 @@ begin
     TestRunner.Caption := DWF_SERVER_FULL_NAME + ' FPCUnit tests';
     Application.Run;
   end;
-
-  {$IFNDEF LINUX}
-  // SetHeapTraceOutput('heaptrace.log');
-  {$ENDIF}
 end.

--- a/test/unittests/djWebFilterTests.pas
+++ b/test/unittests/djWebFilterTests.pas
@@ -66,11 +66,12 @@ end;
 procedure TdjWebFilterTests.TestCreate;
 var
   Context: TdjWebAppContext;
-  // Filter: IWebFilter;
+  Filter: IWebFilter;
 begin
   Context := TdjWebAppContext.Create('x-ctx');
   try
-    (* Filter := *) TTestFilter.Create;
+    Filter := TTestFilter.Create;
+    Check(Assigned(Filter), 'Filter created');
   finally
     Context.Free;
   end;


### PR DESCRIPTION
The FPC **Console** build mode now compiles with `-gh` and `Unittests.lpr` calls `SetHeapTraceOutput('heaptrace.log')`, so every `run-fpc` run drops an FPC leak report at `test/unittests/heaptrace.log`. `UNIT-TESTS.md` gains a section explaining that a green run must be paired with a `heaptrace.log` check (the heap report does not affect the exit code).

Also fixes a real leak surfaced by the report: `djWebFilterTests.TestCreate` constructed a `TTestFilter` (a plain `TInterfacedObject`) without taking a reference, so it was never freed. Now held via an `IWebFilter` and checked.

After this change the only unfreed blocks are Indy unit-initialisation globals (`IdThread` / `IdStack` `..._init$`), which are external and stable:

```
6 unfreed memory blocks : 744
```

FPCUnit (68) and DUnit (68) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)