### PR TITLE
3.2.0: fix the non-design-decision issues + two bug issues

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,7 +1,7 @@
 ![Object Pascal](https://img.shields.io/badge/language-Object%20Pascal-blue.svg)
 ![OS: Windows](https://img.shields.io/badge/OS-Windows-blue)
 ![Delphi 2009+](https://img.shields.io/badge/Delphi-2009+-blue.svg)
-![Lazarus 4.0+](https://img.shields.io/badge/Lazarus-4.0+-blue.svg)
+![Lazarus 4.x](https://img.shields.io/badge/Lazarus-4.x-blue.svg)
 ![GitHub last commit](https://img.shields.io/github/last-commit/michaelJustin/daraja-framework)
 [![Doxygen Docs](https://github.com/michaelJustin/daraja-framework/actions/workflows/doxygen.yml/badge.svg)](https://github.com/michaelJustin/daraja-framework/actions/workflows/doxygen.yml)
 [![pages-build-deployment](https://github.com/michaelJustin/daraja-framework/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/michaelJustin/daraja-framework/actions/workflows/pages/pages-build-deployment)
@@ -100,7 +100,7 @@ https://michaeljustin.github.io/daraja-framework/
 
 ### Getting started with Daraja
 
-https://www.habarisoft.com/daraja_framework/3.1.0/DarajaFrameworkGettingStarted.pdf
+[DarajaFrameworkGettingStarted.pdf](../docs/DarajaFrameworkGettingStarted.pdf) (in this repository)
 
 ## Licensing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to the Daraja HTTP Framework are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Releases are tagged `vMAJOR.MINOR.PATCH` and published at
+<https://github.com/michaelJustin/daraja-framework/releases>.
+
+## [Unreleased]
+
+_Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraja-framework/milestone/17)._
+
+## [3.1.2] - 2026-09-08
+
+### Fixed
+
+- `IWebFilterConfig.GetFilterName` now returns the filter name instead of an
+  empty string. `SetName` was added to `IWriteableConfig`; `TdjWebFilterHolder`
+  passes its `Name` into the config before `Init`. (#415)
+- `TdjWebFilterHolder` and `TdjWebComponentHolder` clear their instance field
+  after freeing it (in `DoStop`, and on a failed filter init), removing a
+  dangling-pointer / repeated-stop hazard. (#415)
+- `TdjPathMap` establishes its sort order when URL patterns are added rather than
+  as a side effect of every `GetMatches` lookup. (#415)
+- `djNCSALogFilter`: correct timezone suffix for UTC offsets west of Greenwich
+  (`DecodeTime` was called on a negative `TDateTime`). (#416)
+
+### Changed
+
+- `djStatisticsFilter.RequestsActive` widened to `Int64` to match the backing
+  counter and the other accessors. (#417)
+
+### Internal
+
+- The FPC `Console` test build is compiled with heap tracing (`-gh`) and writes
+  `heaptrace.log`; `UNIT-TESTS.md` documents checking it on every run. A leaked
+  `TTestFilter` in `djWebFilterTests` was fixed. (#448)
+- Version constant set to `3.1.2`. (#418)
+
+## [3.1.1] - 2026-05-20
+
+### Changed
+
+- Use parametrized logging. (#406)
+- Comment out deprecated methods. (#408)
+
+## [3.1.0] - 2026-05-17
+
+### Changed
+
+- Requires slf4p 1.0.8.
+- `TdjLoggerFactory.GetLogger` calls use a class reference. (#396)
+
+[Unreleased]: https://github.com/michaelJustin/daraja-framework/compare/v3.1.2...HEAD
+[3.1.2]: https://github.com/michaelJustin/daraja-framework/compare/v3.1.1...v3.1.2
+[3.1.1]: https://github.com/michaelJustin/daraja-framework/compare/v3.1.0...v3.1.1
+[3.1.0]: https://github.com/michaelJustin/daraja-framework/compare/v3.0.6...v3.1.0

--- a/source/djContextHandler.pas
+++ b/source/djContextHandler.pas
@@ -112,7 +112,7 @@ type
      *}
     procedure DoStart; override;
     {*
-     * Start the handler.
+     * Stop the handler.
      * @sa TdjLifeCycle
      *}
     procedure DoStop; override;
@@ -213,9 +213,8 @@ procedure TdjContext.ValidateContextPath(const ContextPath: string);
 var
   Ch: Char;
 begin
-  Assert(Pos('\', ContextPath) = 0);
-  Assert(Pos('/', ContextPath) = 0);
-
+  // '/' and '\' are not in the whitelist below, so the case statement rejects
+  // them with EWebComponentException like any other invalid character.
   for Ch in ContextPath do
   begin
     case Ch of

--- a/source/djContextHandlerCollection.pas
+++ b/source/djContextHandlerCollection.pas
@@ -31,50 +31,21 @@ unit djContextHandlerCollection;
 interface
 
 uses
-  {$IFDEF DARAJA_LOGGING}
-  djLogAPI, djLoggerFactory,
-  {$ENDIF DARAJA_LOGGING}
-  djHandlerList,
-  Classes;
+  djHandlerList;
 
 type
   { TdjContextHandlerCollection }
 
   {*
-   * Multiple contexts with the same name are not allowed.
+   * A TdjHandlerList of context handlers.
+   *
+   * Contexts are tried in registration order and the first one that produces a
+   * response wins. Uniqueness of context paths is enforced by TdjServer.Add.
    *}
   TdjContextHandlerCollection = class(TdjHandlerList)
-  strict private
-    {$IFDEF DARAJA_LOGGING}
-    Logger: ILogger;
-    {$ENDIF DARAJA_LOGGING}
-  public
-    {*
-     * Create a collection of context handlers.
-     *}
-    constructor Create; override;
-    {*
-     * Destructor.
-     *}
-    destructor Destroy; override;
+    // pas2dox requires the class declaration to use the end; statement
   end;
 
 implementation
-
-{ TdjContextHandlerCollection }
-
-constructor TdjContextHandlerCollection.Create;
-begin
-  inherited Create;
-
-  {$IFDEF DARAJA_LOGGING}
-  Logger := TdjLoggerFactory.GetLogger(TdjContextHandlerCollection);
-  {$ENDIF DARAJA_LOGGING}
-end;
-
-destructor TdjContextHandlerCollection.Destroy;
-begin
-  inherited;
-end;
 
 end.

--- a/source/djGenericWebComponent.pas
+++ b/source/djGenericWebComponent.pas
@@ -80,9 +80,9 @@ type
     {*
      * Get or create a HTTP session.
      *
-     * @note it requires the current TdjServerContext so calling it from one of the
-     * HTTP method handlers is not possible. It can be called from
-     * the Servive method.
+     * @note it requires the current TdjServerContext, so it cannot be called
+     * from one of the HTTP method handlers (OnGet etc.). It can be called from
+     * the Service method.
      *
      * @note if the context was created with the Auto Session option,
      * this method will always return a session independent of the Create parameter

--- a/source/djHandlerList.pas
+++ b/source/djHandlerList.pas
@@ -69,7 +69,7 @@ type
 implementation
 
 uses
-  djInterfaces,
+  djInterfaces, djGlobal,
   SysUtils;
 
 { TdjHandlerList }
@@ -115,11 +115,16 @@ begin
     {$ENDIF DARAJA_LOGGING}
 
     Response.ResponseNo := 404;
-    Response.ContentText := Format(
-      '<html> %d %s</html>',
-      [ Response.ResponseNo,
-        Response.ResponseText
-      ]);
+    Response.ContentType := 'text/html';
+    Response.ContentText :=
+      '<!DOCTYPE html>' + #10
+      + '<html>' + #10
+      + '<head><title>404 Not Found</title></head>' + #10
+      + '<body>' + #10
+      + '  <h1>404 Not Found</h1>' + #10
+      + '  <p>No resource is mapped to ' + HTMLEncode(Target) + '</p>' + #10
+      + '</body>' + #10
+      + '</html>';
   end;
 end;
 

--- a/source/djHandlerWrapper.pas
+++ b/source/djHandlerWrapper.pas
@@ -71,7 +71,7 @@ type
      *}
     procedure DoStart; override;
     {*
-     * Start the handler.
+     * Stop the handler.
      * @sa TdjLifeCycle
      *}
     procedure DoStop; override;
@@ -170,21 +170,21 @@ end;
 
 procedure TdjHandlerWrapper.RemoveHandler(const Handler: IHandler);
 var
-  Old: IHandler;
   C: IHandlerContainer;
 begin
-  Old := FHandler;
+  if not Assigned(FHandler) then
+  begin
+    raise Exception.Create('Can not remove handler');
+  end;
 
-  if Assigned(Old) then
+  if Handler = FHandler then
   begin
-    Supports(Handler, IHandlerContainer, C);
-    if Assigned(C) then
-    begin
-      C.RemoveHandler(Handler);
-    end;
-  end else if Assigned(Old) and (Handler = Old) then
+    SetHandler(nil);
+  end
+  else if Supports(FHandler, IHandlerContainer, C) then
   begin
-    SetHandler(nil)
+    // the wrapped handler is a container: delegate inward
+    C.RemoveHandler(Handler);
   end
   else
   begin

--- a/source/djServer.pas
+++ b/source/djServer.pas
@@ -130,6 +130,9 @@ type
     {*
      * Add a preconfigured connector.
      *
+     * Ownership: the connector is held by an interface reference and is
+     * released when the server is destroyed. Do not free it yourself.
+     *
      * @param Connector the connector
      *}
     procedure AddConnector(const Connector: IConnector); overload;
@@ -145,8 +148,13 @@ type
     {*
      * Add a new context.
      *
+     * Ownership: the server takes ownership of the context. It is destroyed
+     * together with the server; do not free it yourself. If a context with the
+     * same path is already registered, the passed context is freed and an
+     * EWebComponentException is raised.
+     *
      * @param Context the context handler.
-     * @throws EWebComponentException if an error occurs that interferes with the component's normal operation.
+     * @throws EWebComponentException if the context path is already registered.
      *}
     procedure Add(Context: TdjWebComponentContextHandler);
 
@@ -337,24 +345,13 @@ begin
   end;
 
   try
-    try
-      // start HTTP connectors
-      StartConnectors;
-    except
-      on E: Exception do
-      begin
-        {$IFDEF DARAJA_LOGGING}
-        Logger.Error('Could not start connectors.');
-        {$ENDIF DARAJA_LOGGING}
-        raise;
-      end;
-    end;
-
+    // start HTTP connectors
+    StartConnectors;
   except
     on E: Exception do
     begin
       {$IFDEF DARAJA_LOGGING}
-      Logger.Error('Could not start server.');
+      Logger.Error('Could not start connectors.');
       {$ENDIF DARAJA_LOGGING}
       raise;
     end;

--- a/source/djServerBase.pas
+++ b/source/djServerBase.pas
@@ -99,27 +99,17 @@ begin
   {$IFDEF DARAJA_LOGGING}
   Logger := TdjLoggerFactory.GetLogger(TdjServerBase);
   {$ENDIF DARAJA_LOGGING}
-
-  {$IFDEF LOG_CREATE}
-  Trace('Created');
-  {$ENDIF}
 end;
 
 destructor TdjServerBase.Destroy;
 begin
-  {$IFDEF LOG_DESTROY}
-  Trace('Destroy');
-  {$ENDIF}
-
   inherited;
 end;
 
 procedure TdjServerBase.Handle(const Target: string; Context: TdjServerContext;
   Request: TdjRequest; Response: TdjResponse);
 begin
-
   inherited;
-
 end;
 
 procedure TdjServerBase.DoStart;

--- a/source/djWebAppContext.pas
+++ b/source/djWebAppContext.pas
@@ -39,14 +39,16 @@ type
   { TdjWebAppContext }
 
   {*
-   * Main context handler class.
+   * The context handler class used by applications.
+   *
+   * It is currently a straight alias of TdjWebComponentContextHandler, kept as
+   * the documented public name and an extension point for web-application
+   * specific behaviour.
    *}
   TdjWebAppContext = class(TdjWebComponentContextHandler)
     // pas2dox requires the class declaration to use the end; statement
   end;
 
 implementation
-
-{ TdjWebAppContext }
 
 end.

--- a/source/djWebComponent.pas
+++ b/source/djWebComponent.pas
@@ -49,6 +49,14 @@ type
    * @li OnPost, for HTTP POST requests
    * @li OnPut, for HTTP PUT requests
    * @li OnDelete, for HTTP DELETE requests
+   *
+   * @note Method handling notes and current limitations:
+   * @li every On* handler that is not overridden responds with 405 Method Not
+   *     Allowed. In particular HEAD and OPTIONS are not derived from OnGet -
+   *     override OnHead / OnOptions explicitly if you need them.
+   * @li an unrecognised HTTP method responds with 501 Not Implemented.
+   * @li conditional GET is supported through OnGetLastModified only
+   *     (If-Modified-Since); there is no ETag / If-None-Match handling.
    *}
   TdjWebComponent = class(TdjGenericWebComponent)
   strict private
@@ -157,6 +165,7 @@ uses
 const
   RESOURCE_LAST_MODIFIED_DEFAULT = 0;
   HTTP_ERROR_METHOD_NOT_ALLOWED = 405;
+  HTTP_ERROR_NOT_IMPLEMENTED = 501;
 
 { TdjWebComponent }
 
@@ -291,6 +300,7 @@ begin
         {$IFDEF DARAJA_LOGGING}
         Logger.Error('Unknown HTTP method');
         {$ENDIF DARAJA_LOGGING}
+        Response.ResponseNo := HTTP_ERROR_NOT_IMPLEMENTED;
     end;
   end;
 end;

--- a/source/djWebComponentContextHandler.pas
+++ b/source/djWebComponentContextHandler.pas
@@ -67,26 +67,6 @@ type
      *}
     procedure DoHandle(const Target: string; Context: TdjServerContext;
       Request: TdjRequest; Response: TdjResponse);
-//    {*
-//     * Add a Web Component.
-//     *
-//     * @param Holder holds information about the Web Component
-//     * @param UrlPattern path specification
-//     * @throws EWebComponentException if the Web Component can not be added
-//     * @deprecated for removal
-//     *}
-//    procedure AddWebComponent(Holder: TdjWebComponentHolder;
-//      const UrlPattern: string); overload;
-//    {*
-//     * Add a Web Filter Holder.
-//     *
-//     * @param Holder holds information about the Web Filter
-//     * @param UrlPattern path specification
-//     * @throws Exception if the Web Filter can not be added
-//     * @deprecated for removal
-//     *}
-//    procedure AddWebFilter(Holder: TdjWebFilterHolder;
-//      const UrlPattern: string); overload; deprecated;
   public
     {*
      * Constructor.
@@ -103,6 +83,10 @@ type
 
     {*
      * Add a Web Component.
+     *
+     * Ownership: the returned holder belongs to the context. Use it only for
+     * further configuration (init parameters etc.); do not free it or keep it
+     * past the lifetime of the context.
      *
      * @param ComponentClass WebComponent class
      * @param UrlPattern path specification
@@ -125,6 +109,11 @@ type
 
     {*
      * Add a Web Filter, specifying a WebFilter class
+     *
+     * Ownership: the returned holder belongs to the context. Use it only for
+     * further configuration; do not free it or keep it past the lifetime of the
+     * context. If the filter cannot be added the holder is freed before the
+     * exception propagates.
      *
      * @param FilterClass WebFilter class
      * @param UrlPattern path specification
@@ -224,41 +213,18 @@ begin
   Result := AddWebComponent(ComponentClass, UrlPattern);
 end;
 
-//procedure TdjWebComponentContextHandler.AddWebComponent(Holder: TdjWebComponentHolder;
-//  const UrlPattern: string);
-//begin
-//  // Holder can not be reused.
-//  // Create a new Holder if a Web Component should handle other UrlPatterns.
-//  if Holder.GetContext <> nil then
-//  begin
-//    raise EWebComponentException.CreateFmt(
-//      'Web Component %s is already installed in context %s',
-//      [Holder.WebComponentClass.ClassName, Holder.GetContext.GetContextPath]
-//      );
-//  end;
-//
-//  // set context of Holder to propagate it to WebComponentConfig
-//  Holder.SetContext(Self.GetCurrentContext);
-//
-//  WebComponentHandler.AddWithMapping(Holder, UrlPattern);
-//end;
-
-//procedure TdjWebComponentContextHandler.AddWebFilter(Holder: TdjWebFilterHolder;
-//  const UrlPattern: string);
-//begin
-//  // set context of Holder to propagate it to WebFilterConfig
-//  Holder.SetContext(Self.GetCurrentContext);
-//
-//  WebComponentHandler.AddWebFilter(Holder, UrlPattern);
-//end;
-
 function TdjWebComponentContextHandler.AddWebFilter(
   FilterClass: TdjWebFilterClass; const UrlPattern: string): TdjWebFilterHolder;
 var
   Holder: TdjWebFilterHolder;
 begin
   Holder := TdjWebFilterHolder.Create(FilterClass);
-  WebComponentHandler.AddWebFilter(Holder, UrlPattern);
+  try
+    WebComponentHandler.AddWebFilter(Holder, UrlPattern);
+  except
+    Holder.Free;
+    raise;
+  end;
   Result := Holder;
 end;
 

--- a/source/djWebComponentHandler.pas
+++ b/source/djWebComponentHandler.pas
@@ -502,10 +502,24 @@ procedure TdjWebComponentHandler.AddWebFilter(
 var
   Mapping: TdjWebFilterMapping;
 begin
+  // validate the pattern before touching any state, so a bad pattern fails at
+  // registration time instead of raising during request handling
+  if TdjPathMap.GetSpecType(UrlPattern) = stUnknown then
+  begin
+    raise EWebComponentException.CreateFmt(
+      rsInvalidMappingSForWebComponentS, [UrlPattern, Holder.Name]);
+  end;
+
   if not WebFilters.Contains(Holder) then
   begin
     WebFilters.Add(Holder);
-    SetFilters(WebFilters);
+    try
+      SetFilters(WebFilters);
+    except
+      // leave ownership of Holder with the caller on any failure path
+      WebFilters.Extract(Holder);
+      raise;
+    end;
   end;
 
   Mapping := TdjWebFilterMapping.Create;

--- a/source/optional/djDefaultWebComponent.pas
+++ b/source/optional/djDefaultWebComponent.pas
@@ -54,7 +54,11 @@ type
    *
    * If the file does not exist, a HTTP 404 error will be returned.
    *
-   * @note This class is unsupported demonstration code.
+   * Requests that would resolve outside the static content directory (path
+   * traversal, e.g. "../") are rejected with HTTP 404.
+   *
+   * @note This class is unsupported demonstration code. Review it carefully
+   *       before serving untrusted content from disk.
    *
    * See TdjDefaultWebComponentTests for usage examples.
    *}
@@ -86,7 +90,7 @@ implementation
 uses
   djContextHandler, // to access ROOT_CONTEXT
   djHTTPConstants,
-  SysUtils, Classes;
+  StrUtils, SysUtils, Classes;
 
 { TdjDefaultWebComponent }
 
@@ -155,6 +159,8 @@ procedure TdjDefaultWebComponent.Service(Context: TdjServerContext;
 var
   RelFileName: string;
   FileName: string;
+  BaseDir: string;
+  InsideBase: Boolean;
 begin
   RelFileName := StripContext(Request.Document);
 
@@ -164,6 +170,27 @@ begin
   begin
     // on Winoid systems replace slash with backslash
     FileName := StringReplace(FileName, '/', PathDelim, [rfReplaceAll]);
+  end;
+
+  // resolve '..' / '.' and make sure the request cannot escape the static
+  // content directory (path traversal protection)
+  FileName := ExpandFileName(FileName);
+  BaseDir := IncludeTrailingPathDelimiter(ExpandFileName(BuildAbsolutePath));
+  {$IFDEF MSWINDOWS}
+  InsideBase := StartsText(BaseDir, FileName);
+  {$ELSE}
+  InsideBase := StartsStr(BaseDir, FileName);
+  {$ENDIF}
+  if not InsideBase then
+  begin
+    Response.ResponseNo := 404;
+
+    {$IFDEF DARAJA_LOGGING}
+    Logger.Warn('Rejected path outside static content directory: %s',
+      [Request.Document]);
+    {$ENDIF DARAJA_LOGGING}
+
+    Exit;
   end;
 
   if FileExists(FileName) then

--- a/test/unittests/ConfigAPITests.pas
+++ b/test/unittests/ConfigAPITests.pas
@@ -119,6 +119,7 @@ type
     //procedure TestOneFilterAndTwoWebComponents;
 
     procedure TestMapFilterTwiceToSameWebComponentRaisesException;
+    procedure TestInvalidFilterUrlPatternRaisesException;
     //procedure TestMapFilterWithUnknownComponentNameRaisesException;
     //procedure TestWebFilterHolderInit;
     //procedure TestWebFilterHolderInitHavingTwoInstances;
@@ -1427,6 +1428,25 @@ begin
     CheckGETResponseEquals('from init 1 2 3', '/web/page.filter');
   finally
     Server.Free;
+  end;
+end;
+
+procedure TAPIConfigTests.TestInvalidFilterUrlPatternRaisesException;
+var
+  Context: TdjWebAppContext;
+begin
+  Context := TdjWebAppContext.Create('web');
+  try
+    Context.Add(TExamplePage, '*.html');
+
+    {$IFDEF FPC}
+    ExpectException(EWebComponentException, '');
+    {$ELSE}
+    ExpectedException := EWebComponentException;
+    {$ENDIF}
+    Context.Add(TTestFilter, 'not-a-valid-pattern');
+  finally
+    Context.Free;
   end;
 end;
 

--- a/test/unittests/djDefaultWebComponentTests.pas
+++ b/test/unittests/djDefaultWebComponentTests.pas
@@ -42,6 +42,7 @@ type
     procedure TestDefaultWebComponent;
     procedure TestDefaultWebComponentInRootContext;
     procedure TestMissingFolderDetectedInInit;
+    procedure TestPathTraversalIsRejected;
 
     // other
     procedure TestUpload;
@@ -171,6 +172,27 @@ begin
     Server.Add(Context);
     // ExpectedException := EWebComponentException; there is none
     Server.Start;
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TdjDefaultWebComponentTests.TestPathTraversalIsRejected;
+var
+  Server: TdjServer;
+  Context: TdjWebAppContext;
+begin
+  Server := TdjServer.Create;
+  try
+    Context := TdjWebAppContext.Create('test');
+    Context.Add(TdjDefaultWebComponent, '/');
+    Server.Add(Context);
+    Server.Start;
+
+    // %2e%2e decodes to '..' on the server but the client does not collapse it.
+    // resources\upload.txt exists two levels above webapps\test - the request
+    // must NOT be served.
+    CheckGETResponse404('/test/%2e%2e/%2e%2e/resources/upload.txt');
   finally
     Server.Free;
   end;


### PR DESCRIPTION
Clears the straightforward items from the [3.2.0 milestone](https://github.com/michaelJustin/daraja-framework/milestone/17): everything with an unambiguous fix, plus the two `bug`-labelled issues (#421, #427). Issues that genuinely need a design call are left untouched (#411, #425, #426, #428, #429, #430, #432, #433, #435, #436, #437, #438, #446).

FPCUnit **70** and DUnit **70** pass; `heaptrace.log` shows only the 6 Indy-init blocks.

## Security
- **#419 / #444** — `TdjDefaultWebComponent` resolves `..`/`.` and rejects any request that escapes the static content directory (404). New `TestPathTraversalIsRejected`; doc-comment security note.
- **#449** — `ValidateContextPath` no longer uses `Assert` for the `/`/`\` check.

## Correctness
- **#420** — `TdjHandlerWrapper.RemoveHandler` rewritten (unreachable branch; wrong object tested for delegation).
- **#421** — duplicate web filter name now raises `EWebComponentException` with a clear message instead of a raw `EListError`; `CheckUniqueFilterName` mirrors the web-component check.
- **#422** — web filter URL patterns validated at registration. New `TestInvalidFilterUrlPatternRaisesException`.
- **#424** — `AddWebFilter` failure paths no longer leak the holder.
- **#423** — unknown HTTP method → `501 Not Implemented`.
- **#427** — `TdjPathMap` prefix spec `/foo/*` now also matches the bare `/foo` (Servlet semantics). New assertion in `djPathMapTests`.

## Polish
- **#431** — well-formed default 404 page.
- **#440** — collapsed the redundant nested `try..except` in `TdjServer.DoStart`.
- **#439** — removed broken `{$IFDEF LOG_CREATE} Trace(...)` blocks, the empty `TdjContextHandlerCollection` ctor/dtor, and commented-out deprecated methods.
- **#445** — doc-comment typos.

## Docs
- **#441** — new `CHANGELOG.md`.
- **#442** — README "Getting started" points at the in-repo PDF; Lazarus badge aligned (`4.x`).
- **#434** — ownership/lifetime documented on `TdjServer.Add`, `AddConnector`, and the holder-returning `Add*` methods.
- **#443** — HEAD/OPTIONS/conditional-GET limitations documented on `TdjWebComponent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)