### PR TITLE
Bump version to 3.2.0-SNAPSHOT

### DIFF
--- a/source/djGlobal.pas
+++ b/source/djGlobal.pas
@@ -31,7 +31,7 @@ unit djGlobal;
 interface
 
 const
-  DWF_SERVER_VERSION = '3.1.2';
+  DWF_SERVER_VERSION = '3.2.0-SNAPSHOT';
   DWF_SERVER_FULL_NAME = 'Daraja HTTP Framework ' + DWF_SERVER_VERSION;
   DWF_SERVER_COPYRIGHT = 'Copyright (c) Michael Justin';
 


### PR DESCRIPTION
Opens the 3.2.0 development cycle. `DWF_SERVER_VERSION` `'3.1.2'` -> `'3.2.0-SNAPSHOT'` so dev builds off `master` are distinguishable from the 3.1.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)