### PR TITLE
CI: skip loopback-server integration suites

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,12 @@ jobs:
         with:
           lazarus-version: stable
 
+      # DARAJA_SKIP_SERVER_TESTS excludes the loopback-HTTP-server integration
+      # suites (TSessionTests, TAPIConfigTests) to keep the CI run fast. Their
+      # coverage is exercised by the local run-fpc / run-delphi scripts.
       - name: Build the test runner (Console build mode)
         working-directory: daraja-framework/test/unittests
-        run: lazbuild -B --build-mode=Console Unittests.lpi
+        run: lazbuild -B --build-mode=Console --opt=-dDARAJA_SKIP_SERVER_TESTS Unittests.lpi
         shell: bash
 
       - name: Run the test suite (headless)

--- a/UNIT-TESTS.md
+++ b/UNIT-TESTS.md
@@ -101,8 +101,9 @@ warnings are expected (W1036 `LCloseConnection`, W1035 SSPI).
   is defined (it needs the OpenSSL DLLs).
 - The integration suites that start a loopback HTTP server (`TSessionTests`,
   `TAPIConfigTests`) run everywhere by default. Define `DARAJA_SKIP_SERVER_TESTS`
-  to exclude them on environments where binding a listening socket is not
-  possible.
+  (e.g. `lazbuild --opt=-dDARAJA_SKIP_SERVER_TESTS ...`) to exclude them where
+  binding a listening socket is not possible or not wanted. **CI defines it** —
+  see below.
 
 ## GUI runners
 
@@ -114,6 +115,10 @@ without `-text-mode`) and run the executable with no arguments.
 [`.github/workflows/tests.yml`](.github/workflows/tests.yml) checks out the two
 dependencies as siblings, installs Lazarus, and runs the Free Pascal suite
 headless on every push and pull request that touches `source/` or `test/`.
+
+CI builds with `-dDARAJA_SKIP_SERVER_TESTS`, so the loopback-server integration
+suites (`TSessionTests`, `TAPIConfigTests`) do **not** run in CI. Run
+`run-fpc` / `run-delphi` locally before merging to exercise them.
 
 ## Notes
 


### PR DESCRIPTION
Builds the FPC test runner with `--opt=-dDARAJA_SKIP_SERVER_TESTS`, so `TSessionTests` and `TAPIConfigTests` (which each start a real HTTP server on the loopback interface) no longer run in CI.

- Local: 70 tests -> CI: 17 tests
- CI wall time drops from ~3 min to under a minute
- Integration coverage stays in `run-fpc` / `run-delphi`, which must be run locally before merging

`UNIT-TESTS.md` documents the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)