### PR TITLE
Fix the two remaining bug-labelled issues (#421, #427)

### DIFF
--- a/source/djPathMap.pas
+++ b/source/djPathMap.pas
@@ -176,8 +176,12 @@ begin
     SpecType of
     stPrefix:
       begin
+        // '/foo/*' -> '/foo/'
         Tmp := StringReplace(Spec, '/*', '/', []);
-        Result := Pos(Tmp, Path) = 1;
+        // matches '/foo/' and anything below it, and also the bare '/foo'
+        // (Servlet path mapping semantics)
+        Result := (Pos(Tmp, Path) = 1)
+          or (Path = Copy(Tmp, 1, Length(Tmp) - 1));
       end;
     stSuffix:
       begin

--- a/source/djWebComponentHandler.pas
+++ b/source/djWebComponentHandler.pas
@@ -74,6 +74,7 @@ type
     procedure InitializeHolders(Holders: TdjWebFilterHolders);
     function StripContext(const Doc: string): string;
     procedure CheckUniqueName(Holder: TdjWebComponentHolder);
+    procedure CheckUniqueFilterName(Holder: TdjWebFilterHolder);
     procedure CreateOrUpdateMapping(const UrlPattern: string; Holder:
       TdjWebComponentHolder);
     procedure ValidateMappingUrlPattern(const UrlPattern: string;
@@ -216,6 +217,8 @@ resourcestring
     +'name';
   rsUpdateMappingForWebComponent = 'Update mapping for Web Component "%s" -'
     +'> %s,%s';
+  rsTheWebFilterSCanNotBeAdded = 'The Web Filter "%s" can not be added because '
+    +'a different filter with the same name is already registered';
 
 type
 
@@ -440,6 +443,21 @@ begin
   end;
 end;
 
+procedure TdjWebComponentHandler.CheckUniqueFilterName(Holder: TdjWebFilterHolder);
+var
+  FH: TdjWebFilterHolder;
+begin
+  // fail if a different holder with the same name is already registered
+  for FH in WebFilters do
+  begin
+    if (FH <> Holder) and (FH.Name = Holder.Name) then
+    begin
+      raise EWebComponentException.CreateFmt(rsTheWebFilterSCanNotBeAdded,
+        [Holder.Name]);
+    end;
+  end;
+end;
+
 procedure TdjWebComponentHandler.AddMapping(Mapping: TdjWebComponentMapping);
 begin
   WebComponentMappings.Add(Mapping);
@@ -502,13 +520,15 @@ procedure TdjWebComponentHandler.AddWebFilter(
 var
   Mapping: TdjWebFilterMapping;
 begin
-  // validate the pattern before touching any state, so a bad pattern fails at
+  // validate before touching any state, so a bad registration fails at
   // registration time instead of raising during request handling
   if TdjPathMap.GetSpecType(UrlPattern) = stUnknown then
   begin
     raise EWebComponentException.CreateFmt(
       rsInvalidMappingSForWebComponentS, [UrlPattern, Holder.Name]);
   end;
+
+  CheckUniqueFilterName(Holder);
 
   if not WebFilters.Contains(Holder) then
   begin

--- a/test/unittests/ConfigAPITests.pas
+++ b/test/unittests/ConfigAPITests.pas
@@ -1481,9 +1481,9 @@ begin
   Context.Add(TTestFilter, '*.html');
 
   {$IFDEF FPC}
-  ExpectException(EListError, '');
+  ExpectException(EWebComponentException, '');
   {$ELSE}
-  ExpectedException := EListError;
+  ExpectedException := EWebComponentException;
   {$ENDIF}
   try
     Context.Add(TTestFilter, '*.html');

--- a/test/unittests/djPathMapTests.pas
+++ b/test/unittests/djPathMapTests.pas
@@ -133,6 +133,14 @@ begin
       MatchList.Free;
     end;
 
+    // the bare prefix path also matches (Servlet semantics: '/foo/*' -> '/foo')
+    MatchList := PS.GetMatches('/foo');
+    try
+      CheckEquals('/foo/*', Trim(MatchList.Text));
+    finally
+      MatchList.Free;
+    end;
+
     MatchList := PS.GetMatches('/foo/bar');
     try
       CheckEquals('/foo/*', Trim(MatchList.Text));


### PR DESCRIPTION
The `bug`-labelled issues left out of #450.

## #421 — duplicate web filter registration
Adding a second web filter with the same name raised a raw `EListError`
from the internal name dictionary and left mapping state half-updated.
`TdjWebComponentHandler.AddWebFilter` now calls `CheckUniqueFilterName`
first (mirroring the existing `CheckUniqueName` for web components) and
raises `EWebComponentException` with a clear message before touching any
state. `TestMapFilterTwiceToSameWebComponentRaisesException` updated.

## #427 — prefix path matching
`TdjPathMap` now matches the bare prefix path: a spec `/foo/*` matches
`/foo` as well as `/foo/` and `/foo/bar` (Servlet path-mapping
semantics). New assertion in `djPathMapTests`. Suffix matching (`*.ext`)
is left case-sensitive, which is what the servlet spec intends.

FPCUnit 70 / DUnit 70 pass; heaptrace clean.

Closes #421
Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)