### PR TITLE
Document the init-parameter contract (#437)

### DIFF
--- a/source/djContextHandler.pas
+++ b/source/djContextHandler.pas
@@ -155,8 +155,9 @@ type
     {*
      * Set initialization parameter.
      *
-     * @param Key init parameter name
+     * @param Key init parameter name (case-sensitive)
      * @param Value init parameter value
+     * @throws EWebComponentException if the key is already set
      *}
     procedure SetInitParameter(const Key: string; const Value: string);
 

--- a/source/djInitParameters.pas
+++ b/source/djInitParameters.pas
@@ -37,7 +37,10 @@ uses
 
 type
   {*
-   * Initialization parameters.
+   * Initialization parameters: a map of string keys to string values.
+   *
+   * Following the Servlet model, parameter names are compared case-sensitively
+   * and iteration order is unspecified.
    *}
   TdjInitParameters = TDictionary<string, string>;
 

--- a/source/djInterfaces.pas
+++ b/source/djInterfaces.pas
@@ -133,7 +133,7 @@ type
     {*
      * Gets the value of an initialization parameter.
      *
-     * @param Key The parameter name.
+     * @param Key The parameter name. Parameter names are case-sensitive.
      * @return The parameter value or empty string if not found.
      *}
     function GetInitParameter(const Key: string): string;
@@ -141,6 +141,8 @@ type
     {*
      * Gets all initialization parameter names.
      *
+     * @note The caller owns the returned list and must free it. The order of
+     *       the names is unspecified.
      * @return A list containing all parameter names.
      *}
     function GetInitParameterNames: TdjStrings;
@@ -160,13 +162,15 @@ type
   IWebComponentConfig = interface(IInterface)
     ['{2F61659D-1EF3-4C7A-BDEF-7349A1B4E690}']
     {*
+     * @note The caller owns the returned list and must free it. The order of
+     *       the names is unspecified.
      * @return Names of all initialization parameters
      *}
     function GetInitParameterNames: TdjStrings;
 
     {*
      * Gets an initialization parameter.
-     * @param Key Parameter name
+     * @param Key Parameter name (case-sensitive)
      * @return Parameter value or empty string if not found
      *}
     function GetInitParameter(const Key: string): string;
@@ -184,13 +188,15 @@ type
   IContextConfig = interface(IInterface)
     ['{5304AF56-8180-4B71-9EEF-A50CDB97E67F}']
     {*
+     * @note The caller owns the returned list and must free it. The order of
+     *       the names is unspecified.
      * @return Names of all initialization parameters
      *}
     function GetInitParameterNames: TdjStrings;
 
     {*
      * Gets an initialization parameter.
-     * @param Key Parameter name
+     * @param Key Parameter name (case-sensitive)
      * @return Parameter value or empty string if not found
      *}
     function GetInitParameter(const Key: string): string;
@@ -274,13 +280,15 @@ type
     function GetFilterName: string;
 
     {*
+     * @note The caller owns the returned list and must free it. The order of
+     *       the names is unspecified.
      * @return Names of all initialization parameters
      *}
     function GetInitParameterNames: TdjStrings;
 
     {*
      * Gets an initialization parameter.
-     * @param Key Parameter name
+     * @param Key Parameter name (case-sensitive)
      * @return Parameter value or empty string if not found
      *}
     function GetInitParameter(const Key: string): string;
@@ -337,8 +345,9 @@ type
     ['{A3074743-C2EF-44C6-BD28-27E62F82E598}']
     {*
      * Adds a key-value pair to configuration.
-     * @param Key Parameter name
+     * @param Key Parameter name (case-sensitive)
      * @param Value Parameter value
+     * @throws EWebComponentException if the key is already present
      *}
     procedure Add(const Key: string; const Value: string);
 

--- a/source/djWebComponentHolder.pas
+++ b/source/djWebComponentHolder.pas
@@ -93,8 +93,9 @@ type
     {*
      * Set initialization parameter.
      *
-     * @param Key init parameter name
+     * @param Key init parameter name (case-sensitive)
      * @param Value init parameter value
+     * @throws EWebComponentException if the key is already set
      *}
     procedure SetInitParameter(const Key: string; const Value: string);
 

--- a/source/djWebFilterHolder.pas
+++ b/source/djWebFilterHolder.pas
@@ -81,8 +81,9 @@ type
     {*
      * Set initialization parameter.
      *
-     * @param Key init parameter name
+     * @param Key init parameter name (case-sensitive)
      * @param Value init parameter value
+     * @throws EWebComponentException if the key is already set
      *}
     procedure SetInitParameter(const Key: string; const Value: string);
 


### PR DESCRIPTION
Resolves #437 by documenting the existing contract rather than changing it — it already matches the Servlet model:

- parameter **names are case-sensitive**
- `GetInitParameterNames` order is **unspecified**, and the returned `TdjStrings` is **caller-owned** (must be freed)
- `SetInitParameter` / `IWriteableConfig.Add` raise `EWebComponentException` on a duplicate key

Notes added to `TdjInitParameters`, the `IContext` / `IWebComponentConfig` / `IContextConfig` / `IWebFilterConfig` methods, and the `SetInitParameter` doc-comments on the holders and the context handler.

Doc-comments only — no code change. FPCUnit passes.

(The caller-frees note also covers the non-breaking half of #436, but that issue is left open for the return-type decision.)

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)