### PR TITLE
doxygen: version from source, run on every master push

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -3,8 +3,7 @@ name: Generate Doxygen Docs
 on:
   push:
     branches: [master]
-    paths:
-      - 'source/**/*.pas'
+    tags: ['v*']
   workflow_dispatch:
 
 jobs:
@@ -22,7 +21,11 @@ jobs:
         run: echo "C:\\Program Files\\doxygen\\bin" >> $env:GITHUB_PATH
 
       - name: Generate Doxygen documentation with pas2dox
-        run: doxygen make\\doxygen.cfg
+        shell: bash
+        run: |
+          VER=$(awk -F"'" '/DWF_SERVER_VERSION/ {print $2; exit}' source/djGlobal.pas)
+          echo "Building documentation for version: $VER"
+          ( cat make/doxygen.cfg; echo "PROJECT_NUMBER=$VER" ) | doxygen -
 
       - name: Upload Doxygen warnings
         uses: actions/upload-artifact@v4

--- a/make/doxygen.cfg
+++ b/make/doxygen.cfg
@@ -47,8 +47,11 @@ PROJECT_NAME           = "Daraja HTTP Framework"
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
+#
+# The CI workflow (.github/workflows/doxygen.yml) overrides this with the value
+# of DWF_SERVER_VERSION from source/djGlobal.pas. This is only the local fallback.
 
-PROJECT_NUMBER         = 3.1.2-SNAPSHOT
+PROJECT_NUMBER         = 3.2.0-SNAPSHOT
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a


### PR DESCRIPTION
## Problem
- The published API docs show a hardcoded `PROJECT_NUMBER = 3.1.2-SNAPSHOT` ([make/doxygen.cfg](make/doxygen.cfg#L51)) — stale (master is `3.2.0-SNAPSHOT`).
- `doxygen.yml` had no `pull_request` trigger and a `paths: ['source/**/*.pas']` filter, so it never appears as a PR check and skipped merges that touched no `.pas` file (e.g. #452).

## Changes
- The "Generate" step now extracts `DWF_SERVER_VERSION` from `source/djGlobal.pas` with `awk` and passes it to doxygen via a stdin config override:
  ```bash
  VER=$(awk -F"'" '/DWF_SERVER_VERSION/ {print $2; exit}' source/djGlobal.pas)
  ( cat make/doxygen.cfg; echo "PROJECT_NUMBER=$VER" ) | doxygen -
  ```
- Dropped the `paths:` filter — docs rebuild on every `master` push (~2 min).
- Added `tags: ['v*']` so tagged releases republish the docs.
- `PROJECT_NUMBER` in the cfg kept as a local-build fallback, bumped to `3.2.0-SNAPSHOT`.

Tested locally: `awk` extraction yields `3.2.0-SNAPSHOT`, generated `index.html` shows it, 0 doxygen warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)