### PR TITLE
ci: cache the apt Lazarus/FPC install on Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,12 +41,17 @@ jobs:
           repository: michaelJustin/slf4p
           path: slf4p
 
-      # On Linux, install from the Ubuntu archive (FPC 3.2.2 + Lazarus).
+      # On Linux, install from the Ubuntu archive (FPC 3.2.2 + Lazarus 3.0).
       # The setup-lazarus action pulls .deb files from SourceForge, which
-      # regularly stalls for many minutes on the hosted runners.
+      # regularly stalls for many minutes on the hosted runners. The cache
+      # action restores the .debs on a hit (~15s vs ~2min) and falls back to
+      # a normal apt install on a miss.
       - name: Install FPC and Lazarus (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y lazarus libgtk2.0-dev
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: lazarus libgtk2.0-dev
+          version: 1
 
       - name: Install Lazarus / FPC (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
Trial of `awalsh128/cache-apt-pkgs-action` to shave the ~2 min Linux
`apt-get install lazarus` step.

Unlike `setup-lazarus`'s `with-cache` (which broke the build when the
cache service returned 400), this action falls back to a plain apt
install on a cache miss.

Watching for two things on the runs here:
- cache **miss** (first run): must still install and go green
- cache **hit** (re-run): install step should drop to ~15s, still green,
  and `lazbuild` must be on PATH (the action does not replay `postinst`,
  so update-alternatives registration is the risk).

If the hit run is red or slow, close without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)