### PR TITLE
Remove the never-called IContext.Init method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ _Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraj
 
 ### Removed
 
+- `IContext.Init` / `TdjContext.Init(const Config: IContextConfig)`. It was
+  never called anywhere in the framework and carried a `TODO` questioning
+  whether overwriting the config field was safe; the API docs implied a context
+  lifecycle step that does not exist. (#426, #446)
 - The never-completed "map a web filter to a named web component" machinery
   (`TdjMultiMap`, `TdjWebFilterMapping.WebComponentNames`, the name branch of
   the filter chain). It had no public API and had been dead since June 2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ _Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraj
 - Fixed doc-comment copy/paste errors (`Servive`, "Start the handler" on a
   `DoStop`). (#445)
 - Added this `CHANGELOG.md`. (#441)
+- The internal `IWriteableConfig` interface is excluded from the generated API
+  documentation; it exists only for framework-internal casts. (#446)
 
 ### Internal
 

--- a/source/djContextHandler.pas
+++ b/source/djContextHandler.pas
@@ -73,7 +73,6 @@ type
     procedure SetName(const AName: string);
   protected
     // IContext interface
-    procedure Init(const Config: IContextConfig);
     function GetContextConfig: IContextConfig;
     function GetContextPath: string;
     function GetInitParameter(const Key: string): string;
@@ -245,12 +244,6 @@ begin
         [ContextPath]);
     end;
   end;
-end;
-
-procedure TdjContext.Init(const Config: IContextConfig);
-begin
-  // iow: does it decrease the reference count?
-  FConfig := Config; // TODO check if it is ok to overwrite the field here with a new one
 end;
 
 procedure TdjContext.Add(const Key, Value: string);

--- a/source/djInterfaces.pas
+++ b/source/djInterfaces.pas
@@ -112,13 +112,6 @@ type
   IContext = interface(IInterface)
     ['{19E32FEB-0348-42B2-8977-F03A0032473C}']
     {*
-     * Initializes the context with the given configuration.
-     *
-     * @param Config The context configuration to use.
-     *}
-    procedure Init(const Config: IContextConfig);
-
-    {*
      * Get the context configuration.
      * @return the context configuration
      *}

--- a/source/djInterfaces.pas
+++ b/source/djInterfaces.pas
@@ -330,10 +330,10 @@ type
     procedure DestroyFilter;
   end;
 
-  {*
-   * Interface for writable configuration objects that can be modified at runtime.
-   * @interface IWriteableConfig
-   *}
+  /// \cond
+  // Internal: used only for framework-internal casts when populating a config
+  // object. Not part of the application-facing API, so it is kept out of the
+  // generated documentation.
   IWriteableConfig = interface(IInterface)
     ['{A3074743-C2EF-44C6-BD28-27E62F82E598}']
     {*
@@ -357,6 +357,7 @@ type
      *}
     procedure SetName(const AName: string);
   end;
+  /// \endcond
 
   /// \cond
   // todo move


### PR DESCRIPTION
`TdjContext.Init(const Config: IContextConfig)` was a dead implementation of an
`IContext` interface method: nothing in `source/` ever called it, and it carried
a `TODO` questioning whether overwriting `FConfig` was safe. Its doc-comment
implied a context lifecycle step that never runs.

- Dropped `Init` from the `IContext` interface and from `TdjContext`.
- Excluded the internal `IWriteableConfig` interface from the generated API docs
  (`\cond`/`\endcond`) — it only exists for framework-internal `as` casts and
  was cluttering the public API surface.
- CHANGELOG updated.

`TdjContext` is the only `IContext` implementor; no test or demo referenced the
method. Verified building on both toolchains: Lazarus/FPC `ConsoleCI` (18 tests,
0 failures) and Delphi `dcc32` (only the two known Indy warnings).

Closes #426. Closes #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)