### PR TITLE
Return GetInitParameterNames by value (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ _Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraj
 
 - Init parameters are documented as following the Servlet model: names are
   case-sensitive, `GetInitParameterNames` returns them in an unspecified
-  order in a caller-owned list, and a duplicate key raises. Stated on
+  order, and a duplicate key raises. Stated on
   `TdjInitParameters`, the `IContext` / `I*Config` methods and the
   `SetInitParameter` / `Add` doc-comments. (#437)
 - Documented the HEAD/OPTIONS/conditional-GET limitations on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ _Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraj
 - The fallback 404 page from `TdjHandlerList` is now a well-formed minimal
   HTML document with a `text/html` content type and the HTML-encoded target
   (previously it had empty status text and no content type). (#431)
+- **Breaking:** `GetInitParameterNames` on `IContext`, `IWebComponentConfig`,
+  `IContextConfig` and `IWebFilterConfig` now returns a `TdjStringArray`
+  (`array of string`, returned by value) instead of a `TList<string>` that the
+  caller had to free. Callers replace `L := Config.GetInitParameterNames; try
+  ... finally L.Free; end;` with a plain `for Name in Config.GetInitParameterNames
+  do`. (#436)
 
 ### Removed
 

--- a/source/djAbstractConfig.pas
+++ b/source/djAbstractConfig.pas
@@ -66,7 +66,7 @@ type
   protected
     // IContextConfig interface todo more generic.
     function GetInitParameter(const Key: string): string;
-    function GetInitParameterNames: TdjStrings;
+    function GetInitParameterNames: TdjStringArray;
     function GetName: string;
   public
     {*
@@ -127,15 +127,17 @@ begin
   FParams.TryGetValue(Key, Result);
 end;
 
-function TdjAbstractConfig.GetInitParameterNames: TdjStrings;
+function TdjAbstractConfig.GetInitParameterNames: TdjStringArray;
 var
   S: string;
+  I: Integer;
 begin
-  Result := TdjStrings.Create;
-
+  SetLength(Result, FParams.Count);
+  I := 0;
   for S in FParams.Keys do
   begin
-    Result.Add(S);
+    Result[I] := S;
+    Inc(I);
   end;
 end;
 

--- a/source/djContextHandler.pas
+++ b/source/djContextHandler.pas
@@ -76,7 +76,7 @@ type
     function GetContextConfig: IContextConfig;
     function GetContextPath: string;
     function GetInitParameter(const Key: string): string;
-    function GetInitParameterNames: TdjStrings;
+    function GetInitParameterNames: TdjStringArray;
     procedure Log(const Msg: string);
   public
     {*
@@ -204,7 +204,7 @@ begin
   Result := FConfig.GetInitParameter(Key);
 end;
 
-function TdjContext.GetInitParameterNames: TdjStrings;
+function TdjContext.GetInitParameterNames: TdjStringArray;
 begin
   Result := FConfig.GetInitParameterNames;
 end;

--- a/source/djInterfaces.pas
+++ b/source/djInterfaces.pas
@@ -134,11 +134,10 @@ type
     {*
      * Gets all initialization parameter names.
      *
-     * @note The caller owns the returned list and must free it. The order of
-     *       the names is unspecified.
-     * @return A list containing all parameter names.
+     * @note The order of the names is unspecified.
+     * @return An array containing all parameter names.
      *}
-    function GetInitParameterNames: TdjStrings;
+    function GetInitParameterNames: TdjStringArray;
 
     {*
      * Logs a message to the configured logging system.
@@ -155,11 +154,10 @@ type
   IWebComponentConfig = interface(IInterface)
     ['{2F61659D-1EF3-4C7A-BDEF-7349A1B4E690}']
     {*
-     * @note The caller owns the returned list and must free it. The order of
-     *       the names is unspecified.
+     * @note The order of the names is unspecified.
      * @return Names of all initialization parameters
      *}
-    function GetInitParameterNames: TdjStrings;
+    function GetInitParameterNames: TdjStringArray;
 
     {*
      * Gets an initialization parameter.
@@ -181,11 +179,10 @@ type
   IContextConfig = interface(IInterface)
     ['{5304AF56-8180-4B71-9EEF-A50CDB97E67F}']
     {*
-     * @note The caller owns the returned list and must free it. The order of
-     *       the names is unspecified.
+     * @note The order of the names is unspecified.
      * @return Names of all initialization parameters
      *}
-    function GetInitParameterNames: TdjStrings;
+    function GetInitParameterNames: TdjStringArray;
 
     {*
      * Gets an initialization parameter.
@@ -273,11 +270,10 @@ type
     function GetFilterName: string;
 
     {*
-     * @note The caller owns the returned list and must free it. The order of
-     *       the names is unspecified.
+     * @note The order of the names is unspecified.
      * @return Names of all initialization parameters
      *}
-    function GetInitParameterNames: TdjStrings;
+    function GetInitParameterNames: TdjStringArray;
 
     {*
      * Gets an initialization parameter.

--- a/source/djTypes.pas
+++ b/source/djTypes.pas
@@ -67,6 +67,13 @@ type
    *}
   TdjStrings = TList<string>;
 
+  {*
+   * @class TdjStringArray
+   *
+   * A plain dynamic array of strings, returned by value.
+   *}
+  TdjStringArray = array of string;
+
 implementation
 
 end.

--- a/test/unittests/djWebComponentHolderTests.pas
+++ b/test/unittests/djWebComponentHolderTests.pas
@@ -38,6 +38,7 @@ type
   TdjWebComponentHolderTests = class(TTestCase)
   published
     procedure TestCreate;
+    procedure TestGetInitParameterNames;
   end;
 
 implementation
@@ -76,6 +77,27 @@ begin
     finally
       Holder.Free;
     end;
+  finally
+    Context.Free;
+  end;
+end;
+
+procedure TdjWebComponentHolderTests.TestGetInitParameterNames;
+var
+  Context: TdjWebAppContext;
+  Names: TdjStringArray;
+begin
+  Context := TdjWebAppContext.Create('names-ctx');
+  try
+    Context.SetInitParameter('alpha', '1');
+    Context.SetInitParameter('beta', '2');
+
+    Names := Context.GetCurrentContext.GetInitParameterNames;
+
+    // returned by value: nothing for the caller to free. Order is unspecified.
+    CheckEquals(2, Length(Names), 'parameter count');
+    CheckTrue((Names[0] = 'alpha') or (Names[1] = 'alpha'), 'alpha missing');
+    CheckTrue((Names[0] = 'beta') or (Names[1] = 'beta'), 'beta missing');
   finally
     Context.Free;
   end;


### PR DESCRIPTION
`GetInitParameterNames` on `IContext`, `IWebComponentConfig`, `IContextConfig`
and `IWebFilterConfig` returned a `TList<string>` that the caller had to free —
undocumented for years, easy to leak, and not called anywhere in the framework,
demos or tests.

It now returns **`TdjStringArray`** (a plain `array of string`, new in
`djTypes`) **by value**: nothing to free, and

```pascal
for Name in Config.GetInitParameterNames do
  ...
```

just works. `TArray<string>` was avoided in the interface signatures because
Delphi 2009's compiler rejects it there; a named array type compiles on both
toolchains.

- Added `TdjWebComponentHolderTests.TestGetInitParameterNames`.
- FPC `ConsoleCI` suite green (heaptrace at the 6-block / 744-byte baseline);
  Delphi `dcc32 -B` full build clean (only the known Indy W1035/W1036 warnings).

Closes #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)