### PR TITLE
ci: cache the Windows Lazarus/FPC install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
         os: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
 
     steps:
       - name: Checkout daraja-framework
@@ -48,11 +49,36 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y lazarus libgtk2.0-dev
 
-      - name: Install Lazarus / FPC (Windows)
+      # On Windows the setup-lazarus action installs Lazarus + FPC from the
+      # SourceForge Windows installer into ${RUNNER_TEMP}/installers/lazarus,
+      # which also stalls for many minutes when SourceForge throttles the
+      # runners. Cache that tree (it is self-contained, including its own
+      # fpc.cfg) and skip the download on a hit. Bump the key suffix when the
+      # Lazarus / FPC version changes.
+      - name: Cache Lazarus / FPC (Windows)
         if: runner.os == 'Windows'
+        id: cache-lazarus
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/installers/lazarus
+          key: lazarus-${{ runner.os }}-stable-4.4-fpc-3.2.2
+
+      - name: Install Lazarus / FPC (Windows)
+        if: runner.os == 'Windows' && steps.cache-lazarus.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         uses: gcarreno/setup-lazarus@v3
         with:
           lazarus-version: stable
+
+      # On a cache hit setup-lazarus did not run, so add the same two
+      # directories it would have put on PATH (the IDE/lazbuild dir and the
+      # bundled FPC bin dir).
+      - name: Add cached Lazarus to PATH (Windows)
+        if: runner.os == 'Windows' && steps.cache-lazarus.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          echo "${RUNNER_TEMP}/installers/lazarus" >> "$GITHUB_PATH"
+          echo "${RUNNER_TEMP}/installers/lazarus/fpc/3.2.2/bin/x86_64-win64" >> "$GITHUB_PATH"
 
       # The ConsoleCI build mode is the Console mode plus
       # -dDARAJA_SKIP_SERVER_TESTS, which excludes the loopback-HTTP-server

--- a/UNIT-TESTS.md
+++ b/UNIT-TESTS.md
@@ -117,10 +117,12 @@ without `-text-mode`) and run the executable with no arguments.
 [`.github/workflows/tests.yml`](.github/workflows/tests.yml) checks out the two
 dependencies as siblings and runs the Free Pascal suite headless on both
 `windows-latest` and `ubuntu-latest` for every push and pull request that
-touches `source/` or `test/`. Windows installs Lazarus via `setup-lazarus`;
-Linux installs it from the Ubuntu archive (the action's SourceForge download
-stalls on the hosted Linux runners) and runs the console runner under `xvfb`
-(the runner links the LCL). Delphi is not covered in CI.
+touches `source/` or `test/`. Windows installs Lazarus via `setup-lazarus`,
+with the installed tree cached (keyed on the Lazarus / FPC version) so the
+SourceForge download only happens when the cache misses; Linux installs it
+from the Ubuntu archive (the action's SourceForge download stalls on the
+hosted Linux runners) and runs the console runner under `xvfb` (the runner
+links the LCL). Delphi is not covered in CI.
 
 CI builds the `ConsoleCI` mode, so the loopback-server integration suites
 (`TSessionTests`, `TAPIConfigTests`) do **not** run in CI. Run `run-fpc` /


### PR DESCRIPTION
The `setup-lazarus` action downloads the Lazarus Windows installer from
SourceForge on **every** run. When SourceForge throttles the hosted runners
that step stalls for 10+ minutes (it happened on the #459 merge run — 11 min
and counting). Same root cause the Linux job already sidesteps with `apt`.

**Changes**
- Cache `${RUNNER_TEMP}/installers/lazarus` (the self-contained install tree,
  including its bundled `fpc.cfg`), keyed on the Lazarus/FPC version. On a hit
  the download is skipped; the two dirs `setup-lazarus` adds to PATH (the
  `lazbuild` dir and `fpc/3.2.2/bin/x86_64-win64`) are added manually.
- `timeout-minutes: 20` on the job, `10` on the Windows install step, so a
  SourceForge stall fails fast and re-runs into the cache instead of hanging.

**Verification plan** (learning from the abandoned Linux apt-cache attempt,
where the cache-*hit* path was never exercised before merge):
1. first run here populates the cache (miss) — should be green
2. re-run — must hit the cache, and the build/test steps must still pass with
   `lazbuild` coming only from the restored tree

Will confirm both before this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)