### PR TITLE
Tighten TdjLifeCycle: read-only state, clearer guard names (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ _Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraj
   caller had to free. Callers replace `L := Config.GetInitParameterNames; try
   ... finally L.Free; end;` with a plain `for Name in Config.GetInitParameterNames
   do`. (#436)
+- **Breaking:** `TdjLifeCycle.Started` and `TdjLifeCycle.Stopped` are now
+  read-only properties (they were read/write, and writing one silently flipped
+  the other). Use `Start` / `Stop` to change lifecycle state, or `IsStarted` /
+  `IsStopped` to query it. The protected guards `CheckStarted` / `CheckStopped`
+  are renamed `CheckNotStarted` / `CheckNotStopped` — they raise when the
+  lifecycle is *already* in that state, and the old names read like the opposite
+  assertion. (#438)
 
 ### Removed
 
@@ -67,6 +74,10 @@ _Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraj
 - `TdjWebComponentHandler.AddWebFilter` leaves ownership of the holder with
   the caller on any failure (`WebFilters.Extract`); the holder is then freed
   by `TdjWebComponentContextHandler.AddWebFilter`, closing a leak. (#424)
+- `TdjLifeCycle.Stop` now marks the component stopped even when the custom
+  `DoStop` code raises (the exception is still logged and swallowed, as
+  before), so a failed stop can no longer leave it reporting as started.
+  `ILifeCycle.Stop` documents this swallow-and-still-stop behaviour. (#438)
 
 ### Documentation
 

--- a/source/djContextHandler.pas
+++ b/source/djContextHandler.pas
@@ -334,7 +334,7 @@ end;
 
 procedure TdjContextHandler.SetInitParameter(const Key, Value: string);
 begin
-  CheckStarted;
+  CheckNotStarted;
   (FContext as IWriteableConfig).Add(Key, Value);
 end;
 

--- a/source/djHTTPConnector.pas
+++ b/source/djHTTPConnector.pas
@@ -120,7 +120,7 @@ procedure TdjHTTPConnector.DoStart;
 var
   Binding: TIdSocketHandle;
 begin
-  CheckStarted;
+  CheckNotStarted;
 
   // create binding
   {$IFDEF DARAJA_LOGGING}
@@ -154,7 +154,7 @@ begin
 
     HTTPServer.Active := True;
 
-    Started := True;
+    // TdjLifeCycle.Start sets the started flag once DoStart returns.
 
     {$IFDEF DARAJA_LOGGING}
     Logger.Info('Accepting requests at %s', [HostAndPort]);

--- a/source/djInterfaces.pas
+++ b/source/djInterfaces.pas
@@ -50,6 +50,9 @@ type
 
     {*
      * Stops the component.
+     *
+     * @note Unlike Start, a failure in the custom stop code is logged and
+     * swallowed rather than re-raised; the component is still marked stopped.
      *}
     procedure Stop;
 

--- a/source/djLifeCycle.pas
+++ b/source/djLifeCycle.pas
@@ -51,9 +51,6 @@ type
     {$IFDEF DARAJA_LOGGING}
     Logger: ILogger;
     {$ENDIF DARAJA_LOGGING}
-    procedure SetStarted(const Value: Boolean);
-    procedure SetStopped(const Value: Boolean);
-
   protected
     {*
      * Execute the custom start code.
@@ -66,14 +63,14 @@ type
     procedure DoStop; virtual;
 
     {*
-     * Raises an exception if the lifecycle is in "started" state
+     * Raises an exception if the lifecycle is already in "started" state.
      *}
-    procedure CheckStarted;
+    procedure CheckNotStarted;
 
     {*
-     * Raises an exception if the lifecycle is in "stopped" state
+     * Raises an exception if the lifecycle is already in "stopped" state.
      *}
-    procedure CheckStopped;
+    procedure CheckNotStopped;
 
   public
     // ILifeCycle interface
@@ -85,9 +82,9 @@ type
     constructor Create; virtual;
     destructor Destroy; override;
 
-    // properties
-    property Started: Boolean read FStarted write SetStarted;
-    property Stopped: Boolean read FStopped write SetStopped;
+    // properties (read-only; use Start / Stop to change lifecycle state)
+    property Started: Boolean read FStarted;
+    property Stopped: Boolean read FStopped;
   end;
 
 implementation /// \cond
@@ -97,13 +94,13 @@ uses
 
 { TdjLifeCycle }
 
-procedure TdjLifeCycle.CheckStarted;
+procedure TdjLifeCycle.CheckNotStarted;
 begin
   if Started then
     raise Exception.Create('Component started already!');
 end;
 
-procedure TdjLifeCycle.CheckStopped;
+procedure TdjLifeCycle.CheckNotStopped;
 begin
   if Stopped then
     raise Exception.Create('Component stopped already!');
@@ -142,18 +139,6 @@ begin
   Result := FStopped;
 end;
 
-procedure TdjLifeCycle.SetStarted(const Value: Boolean);
-begin
-  FStarted := Value;
-  FStopped := not Value;
-end;
-
-procedure TdjLifeCycle.SetStopped(const Value: Boolean);
-begin
-  FStopped := Value;
-  FStarted := not Value;
-end;
-
 // methods
 
 procedure TdjLifeCycle.DoStart;
@@ -177,7 +162,8 @@ begin
       // Trace('Starting ...');
       DoStart;
       // Trace('Started');
-      Started := True;
+      FStarted := True;
+      FStopped := False;
     except
       on E: Exception do
       begin
@@ -204,15 +190,19 @@ begin
       // Trace('Stopping ...');
       DoStop;
       // Trace('Stopped');
-      Stopped := True;
     except
       on E: Exception do
       begin
+        // Unlike Start, a failed DoStop is logged and swallowed, not
+        // re-raised. The component is still marked stopped below so it
+        // cannot be left in a half-started state.
         {$IFDEF DARAJA_LOGGING}
         Logger.Error('Stop failed', E);
         {$ENDIF DARAJA_LOGGING}
       end;
     end;
+    FStopped := True;
+    FStarted := False;
   finally
     CS.Leave;
   end;

--- a/source/djServer.pas
+++ b/source/djServer.pas
@@ -334,7 +334,7 @@ end;
 
 procedure TdjServer.DoStart;
 begin
-  CheckStarted;
+  CheckNotStarted;
   // Trace('Starting server');
 
   // add default connector
@@ -362,7 +362,7 @@ end;
 
 procedure TdjServer.DoStop;
 begin
-  CheckStopped;
+  CheckNotStopped;
   StopContextHandlers;
   StopConnectors;
 

--- a/source/djWebComponentHolder.pas
+++ b/source/djWebComponentHolder.pas
@@ -174,7 +174,7 @@ procedure TdjWebComponentHolder.DoStart;
 begin
   inherited;
 
-  CheckStarted;
+  CheckNotStarted;
 
   Assert(FConfig <> nil);
   Assert(FConfig.GetContext <> nil);

--- a/source/djWebFilterHolder.pas
+++ b/source/djWebFilterHolder.pas
@@ -169,7 +169,7 @@ procedure TdjWebFilterHolder.DoStart;
 begin
   inherited;
 
-  CheckStarted;
+  CheckNotStarted;
 
   Assert(FConfig <> nil);
   Assert(FConfig.GetContext <> nil);
@@ -242,7 +242,7 @@ end;
 procedure TdjWebFilterHolder.DoFilter(Context: TdjServerContext;
   Request: TdjRequest; Response: TdjResponse; const Chain: IWebFilterChain);
 begin
-  CheckStopped;
+  CheckNotStopped;
 
   WebFilter.DoFilter(Context, Request, Response, Chain);
 end;

--- a/test/unittests/TestHelper.pas
+++ b/test/unittests/TestHelper.pas
@@ -47,6 +47,7 @@ uses
   HttpsTests,
   {$ENDIF DARAJA_TEST_HTTPS}
   djDefaultWebComponentTests,
+  djLifeCycleTests,
   djPathMapTests,
   djWebAppContextTests,
   djWebComponentHandlerTests,
@@ -77,6 +78,7 @@ var
   Tests: TTestSuite;
 begin
   Tests := TTestSuite.Create(DWF_SERVER_FULL_NAME);
+  Tests.AddTest(TTestSuite.Create(TdjLifeCycleTests));
   Tests.AddTest(TTestSuite.Create(TdjPathMapTests));
   Tests.AddTest(TTestSuite.Create(TdjWebComponentHolderTests));
   Tests.AddTest(TTestSuite.Create(TdjWebComponentHandlerTests));
@@ -102,6 +104,7 @@ end;
 {$ELSE}
 procedure RegisterUnitTests;
 begin
+  RegisterTests('', [TdjLifeCycleTests.Suite]);
   RegisterTests('', [TdjPathMapTests.Suite]);
   RegisterTests('', [TdjWebComponentHolderTests.Suite]);
   RegisterTests('', [TdjWebComponentHandlerTests.Suite]);

--- a/test/unittests/Unittests.dpr
+++ b/test/unittests/Unittests.dpr
@@ -70,6 +70,7 @@ uses
   ConfigAPITests in 'ConfigAPITests.pas',
   HttpsTests in 'HttpsTests.pas',
   djDefaultWebComponentTests in 'djDefaultWebComponentTests.pas',
+  djLifeCycleTests in 'djLifeCycleTests.pas',
   djPathMapTests in 'djPathMapTests.pas',
   djWebAppContextTests in 'djWebAppContextTests.pas',
   djWebComponentHandlerTests in 'djWebComponentHandlerTests.pas',

--- a/test/unittests/Unittests.lpr
+++ b/test/unittests/Unittests.lpr
@@ -38,6 +38,7 @@ uses
   Forms,
   Interfaces,
   djGlobal, djInterfaces, djDefaultWebComponent,
+  djLifeCycleTests,
   djPathMapTests,
   djWebAppContextTests,
   djWebComponentHolderTests,

--- a/test/unittests/djLifeCycleTests.pas
+++ b/test/unittests/djLifeCycleTests.pas
@@ -1,0 +1,113 @@
+(*
+    Daraja HTTP Framework
+    Copyright (c) Michael Justin
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+    You can be released from the requirements of the license by purchasing
+    a commercial license. Buying such a license is mandatory as soon as you
+    develop commercial activities involving the Daraja framework without
+    disclosing the source code of your own applications. These activities
+    include: offering paid services to customers as an ASP, shipping Daraja
+    with a closed source product.
+
+*)
+
+unit djLifeCycleTests;
+
+{$IFDEF FPC}{$MODE DELPHI}{$ENDIF}
+
+interface
+
+uses
+  {$IFDEF FPC}fpcunit,testregistry{$ELSE}TestFramework{$ENDIF};
+
+type
+  TdjLifeCycleTests = class(TTestCase)
+  published
+    procedure TestStartsStopped;
+    procedure TestStartThenStop;
+    procedure TestFailedStopStillCountsAsStopped;
+  end;
+
+implementation
+
+uses
+  djLifeCycle, SysUtils;
+
+type
+  { TFailingLifeCycle - a lifecycle whose custom stop code always fails }
+  TFailingLifeCycle = class(TdjLifeCycle)
+  protected
+    procedure DoStop; override;
+  end;
+
+procedure TFailingLifeCycle.DoStop;
+begin
+  raise Exception.Create('stop failure for test');
+end;
+
+{ TdjLifeCycleTests }
+
+procedure TdjLifeCycleTests.TestStartsStopped;
+var
+  LC: TdjLifeCycle;
+begin
+  LC := TdjLifeCycle.Create;
+  try
+    CheckFalse(LC.IsStarted, 'a fresh lifecycle is not started');
+    CheckTrue(LC.IsStopped, 'a fresh lifecycle is stopped');
+  finally
+    LC.Free;
+  end;
+end;
+
+procedure TdjLifeCycleTests.TestStartThenStop;
+var
+  LC: TdjLifeCycle;
+begin
+  LC := TdjLifeCycle.Create;
+  try
+    LC.Start;
+    CheckTrue(LC.IsStarted, 'started after Start');
+    CheckFalse(LC.IsStopped, 'not stopped after Start');
+
+    LC.Stop;
+    CheckFalse(LC.IsStarted, 'not started after Stop');
+    CheckTrue(LC.IsStopped, 'stopped after Stop');
+  finally
+    LC.Free;
+  end;
+end;
+
+procedure TdjLifeCycleTests.TestFailedStopStillCountsAsStopped;
+var
+  LC: TFailingLifeCycle;
+begin
+  LC := TFailingLifeCycle.Create;
+  try
+    LC.Start;
+    CheckTrue(LC.IsStarted, 'started after Start');
+
+    // DoStop raises; Stop logs and swallows it, but the component must
+    // not be left in a half-started state.
+    LC.Stop;
+    CheckFalse(LC.IsStarted, 'not started after a failed Stop');
+    CheckTrue(LC.IsStopped, 'stopped after a failed Stop');
+  finally
+    LC.Free;
+  end;
+end;
+
+end.


### PR DESCRIPTION
Resolves the three sub-points of #438 (`TdjLifeCycle`, `source/djLifeCycle.pas`).

### 1. `CheckStarted` / `CheckStopped` renamed
They raise when the lifecycle is *already* started / stopped — the names read like the opposite assertion. Renamed to **`CheckNotStarted` / `CheckNotStopped`**. All 7 call sites are framework-internal (`djContextHandler`, `djHTTPConnector`, `djServer`, `djWebComponentHolder`, `djWebFilterHolder`).

### 2. `Started` / `Stopped` are now read-only
They were public **read/write**, and `SetStarted` / `SetStopped` each silently flipped the other flag, so external code (or a stray assignment) could desync lifecycle state. Now `property Started: Boolean read FStarted;` / `read FStopped;`. `Start` / `Stop` write the backing fields directly; `SetStarted` / `SetStopped` are removed. The only in-repo writer outside `djLifeCycle` was a redundant `Started := True` in `TdjHTTPConnector.DoStart` (the base `Start` already sets it once `DoStart` returns) — dropped.

Use `Start` / `Stop` to change state, `IsStarted` / `IsStopped` (on `ILifeCycle`) to query it.

### 3. Failed `DoStop` no longer leaves the component half-started
`Stop` catches and swallows `DoStop` failures (deliberate, unlike `Start`), but `Stopped := True` was never reached on that path. It's now set unconditionally after the `try/except`, so a failed stop still reports as stopped. Behaviour documented on `ILifeCycle.Stop`.

### Tests
New `djLifeCycleTests` (wired into both runners): start/stop transitions, and a `TFailingLifeCycle` whose `DoStop` raises, asserting the component still ends up stopped.

FPC — `lazbuild ConsoleCI` **and** full `run-fpc.sh`: 74 tests, 0 failures, heaptrace clean (6 blocks / 744 bytes, the Indy baseline).
Delphi 2009 — `dcc32 -B` text runner: 74 tests, OK.

Belongs in the "Breaking Changes in v3.2" list for the Getting Started guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)