### PR TITLE
docs: correct the Doxygen CI description in DOC-COMMENTS.md

### DIFF
--- a/DOC-COMMENTS.md
+++ b/DOC-COMMENTS.md
@@ -30,7 +30,10 @@ makedox.cmd
 
 Output goes to `docs/html/` (`OUTPUT_DIRECTORY = docs/html`); the entry point is
 `docs/html/index.html`. Warnings are written to `warnings.log` in the repo root.
-The CI job runs on every push to `master` that touches `source/**/*.pas`.
+The CI job runs on every push to `master` and on every `v*` tag; it appends
+`PROJECT_NUMBER` from `DWF_SERVER_VERSION` in `source/djGlobal.pas` so the site
+always shows the version being built (the `PROJECT_NUMBER` in `doxygen.cfg` is
+only used for local builds).
 
 ### What gets documented
 


### PR DESCRIPTION
The "Building the docs locally" section still described the pre-#456 Doxygen
workflow:

> The CI job runs on every push to `master` that touches `source/**/*.pas`.

[.github/workflows/doxygen.yml](.github/workflows/doxygen.yml) now:
- has no `paths:` filter — it runs on **every** push to `master`
- also runs on every `v*` tag
- appends `PROJECT_NUMBER` from `DWF_SERVER_VERSION` in `source/djGlobal.pas`,
  so the published site always shows the version being built (the
  `PROJECT_NUMBER` in `doxygen.cfg` only applies to local builds)

Text-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)