### PR TITLE
Add test coverage for the todo:test cases in djWebComponentHandler (#465)

### DIFF
--- a/source/djWebComponentHandler.pas
+++ b/source/djWebComponentHandler.pas
@@ -76,8 +76,6 @@ type
     procedure ValidateMappingUrlPattern(const UrlPattern: string;
       Holder: TdjWebComponentHolder);
     function FindMapping(const WebComponentName: string): TdjWebComponentMapping; // overload;
-    function GetFilterChain(const PathInContext: string; Request: TdjRequest;
-      Holder: TdjWebComponentHolder): IWebFilterChain;
     function NewFilterChain(Holder: TdjWebFilterHolder;
       Chain: IWebFilterChain): IWebFilterChain;
     procedure UpdateMappings;
@@ -112,6 +110,18 @@ type
      * @param Mapping The TdjWebComponentMapping instance to be added.
      *}
     procedure AddMapping(Mapping: TdjWebComponentMapping);
+
+    {*
+     * Builds the filter chain that applies to a request path.
+     *
+     * @param PathInContext The request path relative to the context. An empty
+     *        path yields no chain.
+     * @param Request The HTTP request being processed.
+     * @param Holder The web component holder at the end of the chain.
+     * @return The filter chain, or nil if no filter is mapped to the path.
+     *}
+    function GetFilterChain(const PathInContext: string; Request: TdjRequest;
+      Holder: TdjWebComponentHolder): IWebFilterChain;
 
     property WebComponents: TdjWebComponentHolders read FWebComponentHolders;
     property WebFilters: TdjWebFilterHolders read FWebFilterHolders;
@@ -421,7 +431,7 @@ begin
       Logger.Trace(Msg);
       {$ENDIF DARAJA_LOGGING}
 
-      raise EWebComponentException.Create(Msg); // todo test
+      raise EWebComponentException.Create(Msg);
     end;
   end;
 end;
@@ -729,7 +739,8 @@ var
 begin
   Chain := nil;
 
-  if (PathInContext <> '') {todo: test} and (FWebFilterPathMappings <> nil) then
+  // an empty request path (e.g. the bare context root) never maps to a filter
+  if (PathInContext <> '') and (FWebFilterPathMappings <> nil) then
   begin
     for FilterMapping in FWebFilterPathMappings do
     begin

--- a/test/unittests/djWebComponentHandlerTests.pas
+++ b/test/unittests/djWebComponentHandlerTests.pas
@@ -46,6 +46,8 @@ type
     procedure TestTwoContextsFails;
     procedure TestAddSamePathMapTwiceFails;
     procedure TestTwoComponentsSamePathMapFails;
+    procedure TestAddTwoComponentsWithSameNameFails;
+    procedure TestFilterChainForEmptyPathIsNil;
   end;
 
 implementation
@@ -53,7 +55,8 @@ implementation
 uses
   Classes, SysUtils,
   djWebComponentHolder, djWebComponent, djWebAppContext,
-  djWebComponentHandler, djTypes;
+  djWebComponentHandler, djWebFilterHolder, djWebFilter, djInterfaces,
+  djServerContext, djTypes;
 
 type
   TExamplePage = class(TdjWebComponent)
@@ -65,6 +68,12 @@ type
   public
   end;
 
+  TNopFilter = class(TdjWebFilter)
+  public
+    procedure DoFilter({%H-}Context: TdjServerContext; {%H-}Request: TdjRequest;
+      {%H-}Response: TdjResponse; const {%H-}Chain: IWebFilterChain); override;
+  end;
+
   { TExamplePage }
 
 procedure TExamplePage.OnGet(Request: TdjRequest; Response: TdjResponse);
@@ -73,10 +82,18 @@ begin
 
 end;
 
+procedure TNopFilter.DoFilter(Context: TdjServerContext; Request: TdjRequest;
+  Response: TdjResponse; const Chain: IWebFilterChain);
+begin
+  //
+end;
+
 type
   TTestdjWebComponentHandler = class(TdjWebComponentHandler)
   public
     function FindComponent(const ATarget: string): TdjWebComponentHolder;
+    function FilterChainFor(const APath: string;
+      AHolder: TdjWebComponentHolder): IWebFilterChain;
   end;
 
 { TTestdjWebComponentHandler }
@@ -85,6 +102,12 @@ function TTestdjWebComponentHandler.FindComponent(const
   ATarget: string): TdjWebComponentHolder;
 begin
   Result := inherited;
+end;
+
+function TTestdjWebComponentHandler.FilterChainFor(const APath: string;
+  AHolder: TdjWebComponentHolder): IWebFilterChain;
+begin
+  Result := GetFilterChain(APath, nil, AHolder);
 end;
 
 procedure TdjWebComponentHandlerTests.TestAddTwoComponents;
@@ -302,6 +325,84 @@ begin
       Handler.AddWithMapping(H1, '/index.html');
       // add the same component with different path map
       Handler.AddWithMapping(H1, '/other.html');
+    finally
+      Handler.Free;
+    end;
+  finally
+    Context.Free;
+  end;
+end;
+
+procedure TdjWebComponentHandlerTests.TestAddTwoComponentsWithSameNameFails;
+var
+  Context: TdjWebAppContext;
+  H1, H2: TdjWebComponentHolder;
+  Handler: TTestdjWebComponentHandler;
+begin
+  Context := TdjWebAppContext.Create('');
+  try
+    Handler := TTestdjWebComponentHandler.Create;
+    try
+      Handler.SetContext(Context.GetCurrentContext);
+
+      H1 := TdjWebComponentHolder.Create(TExamplePage);
+      H1.Name := 'Duplicate';
+      H1.SetContext(Context.GetCurrentContext);
+      Handler.AddWithMapping(H1, '/a.html');
+
+      // a different holder registered under the same name is rejected
+      H2 := TdjWebComponentHolder.Create(TOtherPage);
+      try
+        H2.Name := 'Duplicate';
+        H2.SetContext(Context.GetCurrentContext);
+
+        {$IFDEF FPC}
+        ExpectException(EWebComponentException);
+        {$ELSE}
+        ExpectedException := EWebComponentException;
+        {$ENDIF}
+
+        Handler.AddWithMapping(H2, '/b.html');
+      finally
+        H2.Free;
+      end;
+    finally
+      Handler.Free;
+    end;
+  finally
+    Context.Free;
+  end;
+end;
+
+procedure TdjWebComponentHandlerTests.TestFilterChainForEmptyPathIsNil;
+var
+  Context: TdjWebAppContext;
+  H1: TdjWebComponentHolder;
+  FH: TdjWebFilterHolder;
+  Handler: TTestdjWebComponentHandler;
+begin
+  Context := TdjWebAppContext.Create('');
+  try
+    Handler := TTestdjWebComponentHandler.Create;
+    try
+      Handler.SetContext(Context.GetCurrentContext);
+
+      H1 := TdjWebComponentHolder.Create(TExamplePage);
+      H1.SetContext(Context.GetCurrentContext);
+      Handler.AddWithMapping(H1, '/index.html');
+
+      FH := TdjWebFilterHolder.Create(TNopFilter);
+      Handler.AddWebFilter(FH, '/*');
+
+      Handler.Start;
+
+      // a real request path resolves to a filter chain
+      Check(Handler.FilterChainFor('/index.html', H1) <> nil,
+        'a filter mapped to /* should build a chain for /index.html');
+
+      // an empty request path short-circuits (the PathInContext <> '' guard)
+      Check(Handler.FilterChainFor('', H1) = nil,
+        'an empty request path must not build a filter chain');
     finally
       Handler.Free;
     end;


### PR DESCRIPTION
Closes #465.

Two `todo: test` markers in `djWebComponentHandler` now have real coverage:

| Marker | Test |
|---|---|
| `CheckUniqueName` — `raise EWebComponentException.Create(Msg); // todo test` | `TestAddTwoComponentsWithSameNameFails` — registering a second, different holder under a name already in use raises |
| `GetFilterChain` — `if (PathInContext <> '') {todo: test} ...` | `TestFilterChainForEmptyPathIsNil` — with a filter mapped to `/*`, a real path builds a chain but an empty request path does not |

`GetFilterChain` moves from `strict private` to `protected` (next to the existing `FindComponent` / `AddMapping` test/extension surface) so the test subclass can call it, and gains a doc comment. The stray markers are removed.

### Verification
- FPC (Lazarus 4.8, `ConsoleCI`): 24 tests, 0 failures, heaptrace clean (6/744 baseline)
- Delphi 2009 (`dcc32 -B`, DUnit text runner): 76 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)