### PR TITLE
Add README.md to demo projects that lacked one

### DIFF
--- a/demo/02_sessions/README.md
+++ b/demo/02_sessions/README.md
@@ -1,0 +1,6 @@
+# Sessions
+
+Shows HTTP session handling: `TSessionDemoResource` counts the GET requests made
+during a session and reports the session ID.
+
+Run and open <http://127.0.0.1/tutorial/session>.

--- a/demo/03_mappings/README.md
+++ b/demo/03_mappings/README.md
@@ -1,0 +1,7 @@
+# Multiple mappings
+
+Maps one web component (`TFibonacciResource`) to two URL patterns, `/fib.txt`
+and `/fib.html`, and varies the response format based on the requested path.
+
+Run and open <http://127.0.0.1/tutorial/fib.html?n=4> or
+<http://127.0.0.1/tutorial/fib.txt?n=4>.

--- a/demo/04_binaryresource/README.md
+++ b/demo/04_binaryresource/README.md
@@ -1,0 +1,6 @@
+# Binary resource
+
+Serves a binary file (`example.pdf`) from a web component, setting the content
+type and streaming the bytes in the response.
+
+Run and open <http://127.0.0.1/tutorial/example.pdf>.

--- a/demo/05_filter/README.md
+++ b/demo/05_filter/README.md
@@ -1,0 +1,7 @@
+# Web filter
+
+A catch-all "Hello, World!" resource with `TResponseHtmlFilter` mapped to
+`*.html`, a web filter that post-processes the response produced by the filter
+chain (wrapping the text in an HTML page).
+
+Run and open <http://127.0.0.1/any/page> or <http://127.0.0.1/any/page.html>.

--- a/demo/06_form_auth_filter/README.md
+++ b/demo/06_form_auth_filter/README.md
@@ -1,0 +1,7 @@
+# Form-based authentication
+
+Session-backed form login. `TFormAuthFilter` guards `/admin` and redirects
+anonymous users to `/login`; `TLoginResource` / `TLogoutResource` manage the
+`auth:username` session value, and `TdjNCSALogFilter` logs all requests.
+
+Run and open <http://127.0.0.1/index.html>.

--- a/demo/15_server_sent_events/README.md
+++ b/demo/15_server_sent_events/README.md
@@ -1,0 +1,7 @@
+# Server-sent events
+
+`TPingResource` streams a `text/event-stream` response, pushing a `ping` event
+with a timestamp and the client's peer address; `THomeResource` serves a page
+that subscribes with an `EventSource`.
+
+Run and open <http://127.0.0.1/>. (Lazarus / FPC project only.)


### PR DESCRIPTION
Six demo folders had no README. Each now has a concise one (title + one or two sentences + the URL to open), matching the light style of `demo/01_helloworld/README.md`:

| Demo | Topic |
|---|---|
| 02_sessions | HTTP session handling / request counter |
| 03_mappings | one component mapped to two URL patterns |
| 04_binaryresource | serving a binary file (PDF) |
| 05_filter | a response-rewriting web filter |
| 06_form_auth_filter | session-backed form login guarding `/admin` |
| 15_server_sent_events | `text/event-stream` push via `TPingResource` |

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)