### PR TITLE
Remove dead code and stale // Trace(...) comments (#463)

### DIFF
--- a/source/djGenericWebComponent.pas
+++ b/source/djGenericWebComponent.pas
@@ -140,7 +140,6 @@ begin
 
   if not Assigned(Result) and Create then
   begin
-    // Trace('Create a new session');
     C := Context as TIdServerContext;
     S := C.Server as TIdCustomHTTPServer;
     Result := S.CreateSession(Context, Response, Request);
@@ -184,7 +183,6 @@ end;
 procedure TdjGenericWebComponent.Service(Context: TdjServerContext;
   Request: TdjRequest; Response: TdjResponse);
 begin
-  // Trace('Service');
 end;
 
 end.

--- a/source/djHTTPConnector.pas
+++ b/source/djHTTPConnector.pas
@@ -99,8 +99,6 @@ begin
 
   Assert(Assigned(Handler));
 
-  // Trace('Configuring');
-
   FHTTPServer := TdjHTTPServer.Create;
 end;
 
@@ -137,7 +135,6 @@ begin
   // detect IPv6
   if Pos(':', Host) > 0 then
   begin
-    // Trace('Using IPv6 binding');
     Binding.IPVersion := Id_IPv6;
   end;
 
@@ -223,7 +220,6 @@ begin
     begin
       // The server side of this connection has disconnected normally but
       // the client has attempted to read or write to the connection.
-      // Trace(ClassName + '.OnCommand: ' + E.ClassName + ' ' + E.Message);
     end;
     on E: Exception do
     begin

--- a/source/djHTTPServer.pas
+++ b/source/djHTTPServer.pas
@@ -101,8 +101,6 @@ begin
   Logger := TdjLoggerFactory.GetLogger(TdjHTTPServer);
   {$ENDIF DARAJA_LOGGING}
 
-  // Trace('Configuring HTTP server');
-
   {$IFDEF DARAJA_LOGGING}
   Logger.Info('Indy version: ' + GetIndyVersion);
   {$ENDIF DARAJA_LOGGING}
@@ -128,7 +126,6 @@ begin
 
   // register context class
   ContextClass := TdjServerContext;
-  // Trace('Context class: ' + TdjServerContext.ClassName);
 end;
 
 procedure TdjHTTPServer.MyOnException(AContext: TIdContext;
@@ -154,12 +151,10 @@ end;
 
 procedure TdjHTTPServer.MySessionStart(Sender: TIdHTTPSession);
 begin
-  // Trace('Session start ' + Sender.RemoteHost);
 end;
 
 procedure TdjHTTPServer.MySessionEnd(Sender: TIdHTTPSession);
 begin
-  // Trace('Session end ' + Sender.RemoteHost);
 end;
 
 procedure TdjHTTPServer.DoMaxConnectionsExceeded(AIOHandler: TIdIOHandler);

--- a/source/djLifeCycle.pas
+++ b/source/djLifeCycle.pas
@@ -159,9 +159,7 @@ begin
   CS.Enter;
   try
     try
-      // Trace('Starting ...');
       DoStart;
-      // Trace('Started');
       FStarted := True;
       FStopped := False;
     except
@@ -187,9 +185,7 @@ begin
   CS.Enter;
   try
     try
-      // Trace('Stopping ...');
       DoStop;
-      // Trace('Stopped');
     except
       on E: Exception do
       begin

--- a/source/djServer.pas
+++ b/source/djServer.pas
@@ -238,8 +238,6 @@ var
 begin
   ConnectorName := '[' + Connector.Host + ']:' + IntToStr(Connector.Port);
 
-  // Trace('Add connector ' + ConnectorName);
-
   ConnectorMap.Add(ConnectorName, Connector);
   ConnectorList.Add(ConnectorName);
 
@@ -297,7 +295,6 @@ begin
     Logger.Trace('Connector %s started', [ConnectorName]);
     {$ENDIF DARAJA_LOGGING}
   end;
-//  Trace('All connectors started');
 end;
 
 procedure TdjServer.StopConnectors;
@@ -324,7 +321,6 @@ begin
   finally
     Keys.Free
   end;
-  // Trace('All connectors stopped');
 end;
 
 procedure TdjServer.StopContextHandlers;
@@ -335,12 +331,10 @@ end;
 procedure TdjServer.DoStart;
 begin
   CheckNotStarted;
-  // Trace('Starting server');
 
   // add default connector
   if ConnectorList.Count = 0 then
   begin
-    // Trace('Add default connector');
     AddConnector(FDefaultHost, FDefaultPort);
   end;
 

--- a/source/djServerBase.pas
+++ b/source/djServerBase.pas
@@ -115,15 +115,11 @@ end;
 procedure TdjServerBase.DoStart;
 begin
   inherited;
-
-  // Trace('Server started');
 end;
 
 procedure TdjServerBase.DoStop;
 begin
   inherited;
-
-  // Trace('Server stopped');
 end;
 
 end.

--- a/source/djWebComponentHandler.pas
+++ b/source/djWebComponentHandler.pas
@@ -476,18 +476,9 @@ begin
     end;
   end;
 
-  // validate and store context
-  // CheckStoreContext(Holder.GetContext);
-
   Holder.SetContext(Self.WebComponentContext);
 
   Assert(Holder.GetContext <> nil);
-
-  // Assign name (if empty)
-  //if Holder.Name = '' then
-  //begin
-  //  Holder.Name := Holder.WebComponentClass.ClassName;
-  //end;
 
   // add the Web Component to list unless it is already there
   if WebComponents.IndexOf(Holder) = -1 then
@@ -622,8 +613,6 @@ var
   Msg2: string;
 begin
   try
-    // Trace('Invoke ' + Comp.ClassName + '.Service');
-
     // invoke service method
     Comp.Service(Context, Request, Response);
 
@@ -643,21 +632,6 @@ begin
           + HTMLEncode(EIdHTTPProtocolException(E).ErrorMessage)
           + '</p>';
       end;
-
-      {$IFDEF DARAJA_LOGGING}
-      // Logger.Warn(Msg, E);
-      {$ENDIF DARAJA_LOGGING}
-
-      {$IFDEF DARAJA_PROJECT_STAGE_DEVELOPMENT}
-      {$IFDEF DARAJA_LOGGING}
-      {$IFDEF DARAJA_MADEXCEPT}
-      // Logger.Warn(string(madStackTrace.StackTrace));
-      {$ENDIF DARAJA_MADEXCEPT}
-      {$IFDEF DARAJA_JCLDEBUG}
-      //Logger.Warn(djStackTrace.GetStackList);
-      {$ENDIF DARAJA_JCLDEBUG}
-      {$ENDIF DARAJA_LOGGING}
-      {$ENDIF DARAJA_PROJECT_STAGE_DEVELOPMENT}
 
       Response.ContentText := '<!DOCTYPE html>' + #10
         + '<html>' + #10

--- a/source/djWebComponentHolder.pas
+++ b/source/djWebComponentHolder.pas
@@ -211,7 +211,6 @@ end;
 
 procedure TdjWebComponentHolder.DoStop;
 begin
-  // Trace('Destroy instance of ' + FClass.ClassName);
   try
     WebComponent.Free;
     FWebComponent := nil;

--- a/source/djWebFilterHolder.pas
+++ b/source/djWebFilterHolder.pas
@@ -210,7 +210,6 @@ end;
 
 procedure TdjWebFilterHolder.DoStop;
 begin
-  // Trace('Destroy instance of ' + FClass.ClassName);
   try
     // Destroy (and ensure that Free will be called)
     try

--- a/source/optional/djDefaultWebComponent.pas
+++ b/source/optional/djDefaultWebComponent.pas
@@ -130,8 +130,6 @@ begin
       'Static resource path not found (%s)',
       [StaticResourcePath]);
   end;
-
-  // Trace('Initialized');
 end;
 
 function TdjDefaultWebComponent.StripContext(const Doc: string): string;


### PR DESCRIPTION
Closes #463. No behaviour change.

- **Stale `// Trace(...)` comments** — ~25 commented-out calls to a `Trace` helper that no longer exists, removed from `djGenericWebComponent`, `djHTTPConnector`, `djHTTPServer`, `djLifeCycle`, `djServer`, `djServerBase`, `djWebComponentHandler`, `djWebComponentHolder`, `djWebFilterHolder`, `optional/djDefaultWebComponent`.
- **Commented-out code in `djWebComponentHandler`** — the `// CheckStoreContext(...)` line, the commented-out "assign name if empty" block, and the empty `{$IFDEF DARAJA_LOGGING}` / `{$IFDEF DARAJA_MADEXCEPT}` / `{$IFDEF DARAJA_JCLDEBUG}` scaffolding wrapping three commented `Logger.Warn` calls in the 500-error handler. The live stack-trace HTML that follows (which does use `madStackTrace` / `djStackTrace`) is unchanged.

### Verification
- FPC (Lazarus 4.8, full `run-fpc.sh`): 76 tests, 0 failures, heaptrace clean (6/744 baseline)
- Delphi 2009 (`dcc32 -B`, DUnit text runner): 76 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)