### PR TITLE
Tidy stray TODO comments in source/ (#466)

### DIFF
--- a/source/djHandlerCollection.pas
+++ b/source/djHandlerCollection.pas
@@ -35,9 +35,14 @@ uses
   djLogAPI, djLoggerFactory,
   {$ENDIF DARAJA_LOGGING}
   djInterfaces, djAbstractHandlerContainer, djServerContext,
-  djTypes;
+  djTypes, Generics.Collections;
 
 type
+  /// \cond
+  // internal: the backing list type for TdjHandlerCollection.FHandlers
+  TdjHandlers = TList<IHandler>;
+  /// \endcond
+
   { TdjHandlerCollection }
 
   {*

--- a/source/djInterfaces.pas
+++ b/source/djInterfaces.pas
@@ -34,7 +34,7 @@ interface
 
 uses
   djServerContext, djTypes,
-  SysUtils, Generics.Collections;
+  SysUtils;
 
 type
   {*
@@ -356,11 +356,6 @@ type
      *}
     procedure SetName(const AName: string);
   end;
-  /// \endcond
-
-  /// \cond
-  // todo move
-  TdjHandlers = TList<IHandler>;
   /// \endcond
 
 implementation

--- a/source/djWebComponentHolder.pas
+++ b/source/djWebComponentHolder.pas
@@ -220,7 +220,8 @@ begin
       {$IFDEF DARAJA_LOGGING}
       Logger.Warn('TdjWebComponentHolder.Stop: ' + E.Message, E);
       {$ENDIF DARAJA_LOGGING}
-      // TODO raise ?;
+      // Swallowed on purpose: TdjLifeCycle.Stop logs and continues so a
+      // failing stop cannot leave the component half-started.
     end;
   end;
 

--- a/source/djWebComponentHolders.pas
+++ b/source/djWebComponentHolders.pas
@@ -40,7 +40,7 @@ type
   // note Delphi 2009 AVs if it is a TObjectList<>
   // see http://stackoverflow.com/questions/289825/why-is-tlist-remove-producing-an-eaccessviolation-error
   // for a workaround
-  // use  TdjWebComponentHolders.Create(TComparer<TdjWebComponentHolder>.Default);
+  // use TdjWebComponentHolders.Create(TComparer<TdjWebComponentHolder>.Default);
 
   { TdjWebComponentHolders }
 

--- a/source/djWebFilterHolder.pas
+++ b/source/djWebFilterHolder.pas
@@ -111,7 +111,8 @@ type
 
   // note Delphi 2009 AVs if it is a TObjectList<>
   // see http://stackoverflow.com/questions/289825/why-is-tlist-remove-producing-an-eaccessviolation-error
-  // for a workaround use TdjWeFilterHolders.Create(TComparer<TdjWebFilterHolder>.Default);
+  // for a workaround
+  // use TdjWebFilterHolders.Create(TComparer<TdjWebFilterHolder>.Default);
   {*
    * A generic list of TdjWebFilterHolder objects.
    *}
@@ -231,7 +232,8 @@ begin
       {$IFDEF DARAJA_LOGGING}
       Logger.Warn('TdjWebFilterHolder.Stop: ' + E.Message, E);
       {$ENDIF DARAJA_LOGGING}
-      // TODO raise ?;
+      // Swallowed on purpose: TdjLifeCycle.Stop logs and continues so a
+      // failing stop cannot leave the filter half-started.
     end;
   end;
 


### PR DESCRIPTION
The parts of #466 that need no decision. No behaviour change.

- **`// TODO raise ?;`** in `TdjWebComponentHolder.DoStop` / `TdjWebFilterHolder.DoStop` → replaced with a comment that the exception is swallowed deliberately, consistent with the `TdjLifeCycle.Stop` swallow-and-still-stop policy from #438.
- **`TdjHandlers = TList<IHandler>`** moved from the public `djInterfaces` unit (it is not an interface) to `djHandlerCollection`, which is its only user, under a `/// \cond` block. `Generics.Collections`, now unused, is dropped from `djInterfaces`.
- **Duplicated "Delphi 2009 AVs" workaround comment** — fixed the `TdjWeFilterHolders` typo and aligned the three copies' whitespace/line-wrapping. Wording and the SO link are unchanged.

Left for #466 (need a decision): the `todo still public` / `todo protected?` / `todo more generic` / `todo: add a constructor` interface-design notes, and the `djDefaultWebComponent` "why is HTML handled differently" question.

### Verification
- FPC (Lazarus 4.8, full `run-fpc.sh`): 76 tests, 0 failures, heaptrace clean (6/744)
- Delphi 2009 (`dcc32 -B`, DUnit text runner): 76 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)