### PR TITLE
TdjDefaultWebComponent: serve every file type the same way (#466)

### DIFF
--- a/source/optional/djDefaultWebComponent.pas
+++ b/source/optional/djDefaultWebComponent.pas
@@ -90,7 +90,7 @@ implementation
 uses
   djContextHandler, // to access ROOT_CONTEXT
   djHTTPConstants,
-  StrUtils, SysUtils, Classes;
+  StrUtils, SysUtils;
 
 { TdjDefaultWebComponent }
 
@@ -197,16 +197,14 @@ begin
     Response.ContentType :=
       Response.HTTPServer.MIMETable.GetFileMIMEType(FileName);
 
-    // TODO: why is HTML handled differently here?
-    if Response.ContentType = 'text/html' then
-    begin
-      Response.ContentStream := TFileStream.Create(FileName, fmOpenRead or
-        fmShareDenyNone);
-    end
-    else
-    begin
-      Response.SmartServeFile(Context, Request, FileName);
-    end;
+    // Serve every file type the same way. SmartServeFile adds conditional GET
+    // (304 Not Modified via If-Modified-Since), sets Last-Modified, and uses
+    // the operating system file transfer fast path. Set an explicit "inline"
+    // Content-Disposition first: otherwise SmartServeFile falls back to
+    // "attachment; filename=..." and the browser downloads index.html instead
+    // of rendering it.
+    Response.ContentDisposition := 'inline';
+    Response.SmartServeFile(Context, Request, FileName);
 
     {$IFDEF DARAJA_LOGGING}
     Logger.Trace('Resource found: %s', [RelFileName]);

--- a/test/unittests/HTTPTestCase.pas
+++ b/test/unittests/HTTPTestCase.pas
@@ -75,7 +75,14 @@ type
     procedure CheckCachedGETResponseEquals(IfModifiedSince: TDateTime; Expected: string; URL: string = ''; msg: string = '');
     procedure CheckCachedGETResponseIs304(IfModifiedSince: TDateTime; URL: string = ''; msg: string = '');
 
+    // GET the URL, then GET it again echoing back the Last-Modified response
+    // header as If-Modified-Since; checks that the second response is 304.
+    procedure CheckConditionalGETIs304(URL: string = ''; msg: string = '');
+
     procedure CheckContentTypeEquals(Expected: string; URL: string = ''; msg: string = '');
+
+    // GET the URL and compare a single response header value.
+    procedure CheckGETResponseHeaderEquals(const HeaderName, Expected: string; URL: string = ''; msg: string = '');
 
     procedure Upload(URL: string; const SourceFile: string);
 
@@ -129,6 +136,23 @@ begin
   CheckEquals(304, Actual, msg);
 end;
 
+procedure THTTPTestCase.CheckConditionalGETIs304(URL: string = ''; msg: string = '');
+var
+  LastMod: TDateTime;
+begin
+  if Pos('http', URL) <> 1 then URL := StrHttp127001 + URL;
+
+  IdHTTP.Get(URL);
+  LastMod := IdHTTP.Response.LastModified;
+  CheckTrue(LastMod > 0, 'server did not send a Last-Modified header');
+
+  IdHTTP.Request.LastModified := LastMod;
+  IdHTTP.HTTPOptions := IdHTTP.HTTPOptions + [hoNoProtocolErrorException];
+
+  IdHTTP.Get(URL);
+  CheckEquals(304, IdHTTP.ResponseCode, msg);
+end;
+
 procedure THTTPTestCase.CheckContentTypeEquals(Expected: string; URL: string;
   msg: string);
 begin
@@ -136,6 +160,15 @@ begin
 
   IdHTTP.Get(URL);
   CheckEquals(Expected, IdHTTP.Response.ContentType, msg);
+end;
+
+procedure THTTPTestCase.CheckGETResponseHeaderEquals(const HeaderName,
+  Expected: string; URL: string = ''; msg: string = '');
+begin
+  if Pos('http', URL) <> 1 then URL := StrHttp127001 + URL;
+
+  IdHTTP.Get(URL);
+  CheckEquals(Expected, IdHTTP.Response.RawHeaders.Values[HeaderName], msg);
 end;
 
 procedure THTTPTestCase.CheckGETResponse200(URL: string; msg: string);

--- a/test/unittests/djDefaultWebComponentTests.pas
+++ b/test/unittests/djDefaultWebComponentTests.pas
@@ -43,6 +43,9 @@ type
     procedure TestDefaultWebComponentInRootContext;
     procedure TestMissingFolderDetectedInInit;
     procedure TestPathTraversalIsRejected;
+    procedure TestHtmlServedInline;
+    procedure TestNonHtmlServedInline;
+    procedure TestStaticFileSupportsConditionalGet;
 
     // other
     procedure TestUpload;
@@ -193,6 +196,68 @@ begin
     // resources\upload.txt exists two levels above webapps\test - the request
     // must NOT be served.
     CheckGETResponse404('/test/%2e%2e/%2e%2e/resources/upload.txt');
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TdjDefaultWebComponentTests.TestHtmlServedInline;
+var
+  Server: TdjServer;
+  Context: TdjWebAppContext;
+begin
+  Server := TdjServer.Create;
+  try
+    Context := TdjWebAppContext.Create('test');
+    Context.Add(TdjDefaultWebComponent, '/');
+    Server.Add(Context);
+    Server.Start;
+
+    // HTML must render in the browser, not download: Content-Disposition
+    // is "inline", never "attachment; filename=...".
+    CheckGETResponseHeaderEquals('Content-Disposition', 'inline',
+      '/test/static.html');
+    CheckGETResponseEquals('staticcontent', '/test/static.html');
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TdjDefaultWebComponentTests.TestNonHtmlServedInline;
+var
+  Server: TdjServer;
+  Context: TdjWebAppContext;
+begin
+  Server := TdjServer.Create;
+  try
+    Context := TdjWebAppContext.Create('test');
+    Context.Add(TdjDefaultWebComponent, '/');
+    Server.Add(Context);
+    Server.Start;
+
+    CheckContentTypeEquals('text/plain', '/test/data.txt');
+    CheckGETResponseHeaderEquals('Content-Disposition', 'inline',
+      '/test/data.txt');
+    CheckGETResponseEquals('plain text payload', '/test/data.txt');
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TdjDefaultWebComponentTests.TestStaticFileSupportsConditionalGet;
+var
+  Server: TdjServer;
+  Context: TdjWebAppContext;
+begin
+  Server := TdjServer.Create;
+  try
+    Context := TdjWebAppContext.Create('test');
+    Context.Add(TdjDefaultWebComponent, '/');
+    Server.Add(Context);
+    Server.Start;
+
+    // a repeat request with If-Modified-Since gets 304 Not Modified
+    CheckConditionalGETIs304('/test/static.html');
   finally
     Server.Free;
   end;

--- a/test/unittests/webapps/test/data.txt
+++ b/test/unittests/webapps/test/data.txt
@@ -1,0 +1,1 @@
+plain text payload


### PR DESCRIPTION
Resolves the `// TODO: why is HTML handled differently here?` in `TdjDefaultWebComponent.Service` (#466, item 6, option b).

### Why the branch existed
Non-HTML files went through Indy's `SmartServeFile` → `ServeFile`, which:
- adds conditional GET (**304 Not Modified**), `Last-Modified`, and the OS file-transfer fast path — good;
- but also stamps `Content-Disposition: attachment; filename="..."` whenever that header is unset — which would make a browser **download `index.html`** instead of rendering it.

So HTML was special-cased to a plain `ContentStream`, trading away 304 + fast transfer just to stay renderable.

### Change
Set `Response.ContentDisposition := 'inline'` before `SmartServeFile` and drop the branch. Now every static file gets conditional GET + efficient transfer **and** renders inline.

### Tests
- `TestHtmlServedInline` / `TestNonHtmlServedInline` — `Content-Disposition: inline` for `.html` and `.txt` (previously `.html` never set it and non-HTML would have been `attachment`)
- `TestStaticFileSupportsConditionalGet` — repeat GET with `If-Modified-Since` → 304 (HTML could not do this before)
- `HTTPTestCase`: new `CheckConditionalGETIs304` / `CheckGETResponseHeaderEquals` helpers; `webapps/test/data.txt` fixture

### Verification
- FPC (Lazarus 4.8, full `run-fpc.sh`): 79 tests, 0 failures, heaptrace clean (6/744)
- Delphi 2009 (`dcc32 -B`, DUnit text runner): 79 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)