### PR TITLE
Drop stale interface-visibility TODO comments (#466)

### DIFF
--- a/source/djAbstractConfig.pas
+++ b/source/djAbstractConfig.pas
@@ -64,7 +64,7 @@ type
     procedure SetContext(const Context: IContext);
     procedure SetName(const AName: string);
   protected
-    // IContextConfig interface todo more generic.
+    // IContextConfig interface
     function GetInitParameter(const Key: string): string;
     function GetInitParameterNames: TdjStringArray;
     function GetName: string;

--- a/source/djGenericWebComponent.pas
+++ b/source/djGenericWebComponent.pas
@@ -55,7 +55,7 @@ type
     {$ENDIF DARAJA_LOGGING}
     FConfig: IWebComponentConfig;
   public
-    // IWebComponent interface todo protected?
+    // IWebComponent interface
     procedure Init(const Config: IWebComponentConfig); overload; virtual;
     procedure Service(Context: TdjServerContext; Request: TdjRequest;
       Response: TdjResponse); virtual;

--- a/source/djGenericWebFilter.pas
+++ b/source/djGenericWebFilter.pas
@@ -59,7 +59,7 @@ type
     {$ENDIF DARAJA_LOGGING}
     FConfig: IWebFilterConfig;
   public
-    // IWebFilter interface todo protected?
+    // IWebFilter interface
     procedure Init(const Config: IWebFilterConfig); overload; virtual;
     procedure DoFilter(Context: TdjServerContext; Request: TdjRequest; Response:
       TdjResponse; const Chain: IWebFilterChain); virtual;

--- a/source/djHandlerWrapper.pas
+++ b/source/djHandlerWrapper.pas
@@ -80,7 +80,7 @@ type
     procedure Handle(const Target: string; Context: TdjServerContext;
       Request: TdjRequest; Response: TdjResponse); override;
   public
-    // IHandlerContainer interface todo still public
+    // IHandlerContainer interface
     {*
      * Add a handler to the container.
      * This implementation of AddHandler calls SetHandler with the passed


### PR DESCRIPTION
Final part of #466 (items 1-4). Comment text only, no code change.

Four section-marker comments each carried an unresolved `todo` about member visibility; none warrants a change:

| File | Was | Now |
|------|-----|-----|
| `djHandlerWrapper.pas` | `// IHandlerContainer interface todo still public` | `// IHandlerContainer interface` |
| `djGenericWebComponent.pas` | `// IWebComponent interface todo protected?` | `// IWebComponent interface` |
| `djGenericWebFilter.pas` | `// IWebFilter interface todo protected?` | `// IWebFilter interface` |
| `djAbstractConfig.pas` | `// IContextConfig interface todo more generic.` | `// IContextConfig interface` |

- `AddHandler` / `RemoveHandler` on `TdjHandlerWrapper` must stay public: `TdjServerBase` re-declares `IHandlerContainer` as public API and `djServer` calls it through the interface.
- `TdjGenericWebComponent` / `TdjGenericWebFilter` keep `Init` / `Service` / `DoFilter` public to match `TdjWebComponent`, the class users subclass.
- `TdjAbstractConfig` already is the generic base shared by `TdjContextConfig`, `TdjWebComponentConfig`, `TdjWebFilterConfig`.

With #471 and #472 this closes #466.

FPC ConsoleCI build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)