### PR TITLE
Resolve the config-before-init TODOs in context/holder (#464)

### DIFF
--- a/source/djContextHandler.pas
+++ b/source/djContextHandler.pas
@@ -184,7 +184,9 @@ begin
 
   ValidateContextPath(ContextPath);
 
-  // TODO check why creation is needed here (actually it is accessed before init is called)
+  // FConfig must exist before the first GetContextConfig / Add call, which run
+  // at configuration time (adding a component or an init parameter). A context
+  // has no separate init step, so the constructor is the only place for this.
   FConfig := TdjContextConfig.Create;
   FContextPath := ContextPath;
 end;

--- a/source/djWebComponentHolder.pas
+++ b/source/djWebComponentHolder.pas
@@ -160,7 +160,8 @@ end;
 procedure TdjWebComponentHolder.SetContext(const Context: IContext);
 begin
   Assert(Context <> nil);
-  Assert(Context.GetContextConfig <> nil); // TODO check this happens before Context init is called
+  // always non-nil: TdjContext creates its config in the constructor
+  Assert(Context.GetContextConfig <> nil);
   (FConfig as IWriteableConfig).SetContext(Context);
 end;
 


### PR DESCRIPTION
Closes #464. Comment text only, no code change.

### Finding
`TdjContext` creates `FConfig` in its constructor. Both TODO comments questioning that were written when `TdjContext` still had an `Init(const Config: IContextConfig)` method that reassigned `FConfig`; #426 (`2243d6b`) removed that method as dead code.

The eager creation **is required**:
- `GetContextConfig`, `GetInitParameter`, `GetInitParameterNames` and `Add` all dereference `FConfig` unconditionally — no lazy creation anywhere.
- `FConfig` is used at configuration time, right after construction and before start: the first `Context.Add(component)` → `Holder.SetContext(GetCurrentContext)` → `Context.GetContextConfig` (the assert in `djWebComponentHolder`), and `SetInitParameter` → `(FContext as IWriteableConfig).Add`.
- Since #426 there is no context init step, so the constructor is the only lifecycle hook before use.
- `TdjContextConfig` construction has no external dependencies, so deferring gains nothing.

### Change
- [djContextHandler.pas](source/djContextHandler.pas): `// TODO check why creation is needed here …` → a note stating the invariant.
- [djWebComponentHolder.pas](source/djWebComponentHolder.pas): `Assert(Context.GetContextConfig <> nil); // TODO check this happens before Context init is called` → keep the assert (cheap sanity check), replace the comment with `// always non-nil: TdjContext creates its config in the constructor`.

FPC ConsoleCI build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)