### PR TITLE
Docs review: fence off every implementation section, correct stale doc statements

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -34,10 +34,14 @@ __Daraja__ is a compact and flexible HTTP server application framework for Objec
  - **Filter chains** &mdash; pluggable pre- and post-processing of requests and responses
  - **Contexts** &mdash; group resources under a base path with their own init parameters
  - **HTTP sessions** &mdash; server-side session state with configurable timeout
- - **Static content** &mdash; serve files from a directory with path-traversal protection
+ - **Static content** &mdash; serve files from a directory with path-traversal protection (`TdjDefaultWebComponent`, see the note below)
  - **Optional helpers** &mdash; NCSA access logging and request-statistics filters
  - **Dual compiler support** &mdash; one codebase for Delphi 2009+ and Lazarus 4.x / FPC 3.2.x
  - **AGPL or commercial** &mdash; 100% open source, with a commercial license available
+
+The static-content web component and the helper filters live in
+[`source/optional/`](../source/optional/), which is unsupported example code:
+review it before using it to serve untrusted content.
 
 ## Usage
 

--- a/DOC-COMMENTS.md
+++ b/DOC-COMMENTS.md
@@ -124,7 +124,9 @@ conditional-section markers which use `\`. The vocabulary actually used in
 | `@li <text>` | bullet list item (used in the overview and class summaries) |
 | `@sa <ref>` | "see also"; may point at a URL (e.g. an RFC) |
 | `@mainpage`, `@section <id> <title>`, `@subsection` | structure of the overview page in `djServer.pas` |
-| `@enum <Name>`, `@interface <Name>` | tell the C-mode parser what the following entity is |
+| `@enum <Name>`, `@interface <Name>`, `@class <Name>` | tell the C-mode parser what the following entity is (`@class` is used for the type aliases and the exception class in `djTypes.pas`) |
+| `@implements <Interface>` | the interfaces a class realises, e.g. on `TdjAbstractConfig` and `TdjContext` |
+| `@tparam <Name> <text>` | generic type parameter (only `TdjGenericHolder<T>`) |
 | `\link <target> <text> \endlink` | cross-reference with custom link text |
 
 `MARKDOWN_SUPPORT = YES` (with `MARKDOWN_STRICT = YES`), so Markdown formatting
@@ -145,7 +147,8 @@ is available inside comment blocks. Raw HTML is also accepted — the overview u
   ```
 
 * Individual internal members are marked `/// \private` (for example the
-  `TdjLifeCycle` overrides `DoStart` / `DoStop`).
+  `DoStart` / `DoStop` overrides in `TdjServer`, `TdjAbstractHandler`,
+  `TdjHandlerCollection`, `TdjHTTPConnector` and `TdjWebComponentHolder`).
 
 * Internal type aliases are wrapped in `/// \cond` … `/// \endcond`.
 

--- a/UNIT-TESTS.md
+++ b/UNIT-TESTS.md
@@ -104,8 +104,10 @@ warnings are expected (W1036 `LCloseConnection`, W1035 SSPI).
   to exclude them where binding a listening socket is not possible or not
   wanted. The **`ConsoleCI`** build mode is the `Console` mode with that define
   baked in (`lazbuild -B --build-mode=ConsoleCI Unittests.lpi` &rarr;
-  `UnittestsConsoleCI`); CI builds it. A `lazbuild --opt=-d...` flag would also
-  work with a recent Lazarus, but Lazarus 3.0's `lazbuild` rejects `--opt`.
+  `UnittestsConsoleCI`); CI builds it. The define lives in a build mode rather
+  than a `lazbuild --opt=-d...` flag because `--opt` was rejected by the
+  `lazbuild` of the day (Lazarus 3.0); newer versions accept it, but the build
+  mode keeps the CI invocation working on either.
 
 ## GUI runners
 
@@ -116,9 +118,11 @@ without `-text-mode`) and run the executable with no arguments.
 
 [`.github/workflows/tests.yml`](.github/workflows/tests.yml) checks out the two
 dependencies as siblings and runs the Free Pascal suite headless on both
-`windows-latest` and `ubuntu-latest` for every push and pull request that
-touches `source/` or `test/`. Windows installs Lazarus via `setup-lazarus`,
-with the installed tree cached (keyed on the Lazarus / FPC version) so the
+`windows-latest` and `ubuntu-latest`. It triggers on every push to `master`
+and on every pull request that touches `source/`, `test/` or the workflow
+file itself, and can be started by hand (`workflow_dispatch`). Windows
+installs Lazarus via `setup-lazarus` (the `stable` version), with the
+installed tree cached (keyed on the Lazarus / FPC version) so the
 SourceForge download only happens when the cache misses; Linux installs it
 from the Ubuntu archive (the action's SourceForge download stalls on the
 hosted Linux runners) and runs the console runner under `xvfb` (the runner

--- a/demo/readme.md
+++ b/demo/readme.md
@@ -1,3 +1,3 @@
 # Demo projects
 
-This folder contains several simple demo applications, which start a local HTTP server and expose one ore more resource URLs.
+This folder contains several simple demo applications, which start a local HTTP server and expose one or more resource URLs.

--- a/source/djAbstractConfig.pas
+++ b/source/djAbstractConfig.pas
@@ -90,7 +90,7 @@ type
 
   end;
 
-implementation
+implementation /// \cond
 
 { TdjAbstractConfig }
 
@@ -162,5 +162,5 @@ begin
   FContext := Context;
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djAbstractHandler.pas
+++ b/source/djAbstractHandler.pas
@@ -65,7 +65,7 @@ type
     constructor Create; override;
   end;
 
-implementation
+implementation /// \cond
 
 { TdjAbstractHandler }
 
@@ -93,4 +93,4 @@ begin
   {$ENDIF DARAJA_LOGGING}
 end;
 
-end.
+end. /// \endcond

--- a/source/djAbstractHandlerContainer.pas
+++ b/source/djAbstractHandlerContainer.pas
@@ -49,8 +49,8 @@ type
     procedure RemoveHandler(const Handler: IHandler); virtual; abstract;
   end;
 
-implementation
+implementation /// \cond
 
 { TdjAbstractHandlerContainer }
 
-end.
+end. /// \endcond

--- a/source/djContextConfig.pas
+++ b/source/djContextConfig.pas
@@ -41,7 +41,7 @@ type
    *}
   TdjContextConfig = class(TdjAbstractConfig, IContextConfig);
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond
 

--- a/source/djContextHandler.pas
+++ b/source/djContextHandler.pas
@@ -166,7 +166,7 @@ type
     property ErrorHandler: IHandler read FErrorHandler write SetErrorHandler;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   SysUtils;
@@ -364,5 +364,5 @@ begin
   {$ENDIF DARAJA_LOGGING}
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djContextHandlerCollection.pas
+++ b/source/djContextHandlerCollection.pas
@@ -46,6 +46,6 @@ type
     // pas2dox requires the class declaration to use the end; statement
   end;
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond

--- a/source/djGenericHolder.pas
+++ b/source/djGenericHolder.pas
@@ -59,7 +59,7 @@ type
     property Name: string read FName write FName;
   end;
 
-implementation
+implementation /// \cond
 
 constructor TdjGenericHolder<T>.Create(AClass: TInterfacedClass);
 begin
@@ -72,4 +72,4 @@ begin
 end;
 
 
-end.
+end. /// \endcond

--- a/source/djGenericWebComponent.pas
+++ b/source/djGenericWebComponent.pas
@@ -99,7 +99,7 @@ type
       const Create: Boolean = True): TIdHTTPSession;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   IdCustomTCPServer;
@@ -185,5 +185,5 @@ procedure TdjGenericWebComponent.Service(Context: TdjServerContext;
 begin
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djGenericWebFilter.pas
+++ b/source/djGenericWebFilter.pas
@@ -91,7 +91,7 @@ type
     property Config: IWebFilterConfig read GetWebFilterConfig;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   {$IFDEF FPC}{$NOTES OFF}{$ENDIF}{$HINTS OFF}{$WARNINGS OFF}
@@ -169,5 +169,5 @@ begin
   {$ENDIF DARAJA_LOGGING}
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djHTTPConstants.pas
+++ b/source/djHTTPConstants.pas
@@ -34,6 +34,6 @@ const
   HTTP_OK = 200;
   HTTP_INTERNAL_SERVER_ERROR = 500;
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond

--- a/source/djHTTPServer.pas
+++ b/source/djHTTPServer.pas
@@ -82,7 +82,7 @@ type
     property OnCommandGet;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   djServerContext,
@@ -164,5 +164,5 @@ begin
   {$ENDIF DARAJA_LOGGING}
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djHandlerList.pas
+++ b/source/djHandlerList.pas
@@ -66,7 +66,7 @@ type
     constructor Create; override;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   djInterfaces, djGlobal,
@@ -128,4 +128,4 @@ begin
   end;
 end;
 
-end.
+end. /// \endcond

--- a/source/djHandlerWrapper.pas
+++ b/source/djHandlerWrapper.pas
@@ -98,7 +98,7 @@ type
     property Handler: IHandler read GetHandler write SetHandler;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   {$IFDEF FPC}{$NOTES OFF}{$ENDIF}{$HINTS OFF}{$WARNINGS OFF}
@@ -233,5 +233,5 @@ begin
   end;
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djInitParameters.pas
+++ b/source/djInitParameters.pas
@@ -44,6 +44,6 @@ type
    *}
   TdjInitParameters = TDictionary<string, string>;
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond

--- a/source/djPlatform.pas
+++ b/source/djPlatform.pas
@@ -39,12 +39,12 @@ uses
 
 function GetTickCount: TIdTicks;
 
-implementation
+implementation /// \cond
 
 function GetTickCount: TIdTicks;
 begin
   Result := IdGlobal.Ticks64;
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djServerBase.pas
+++ b/source/djServerBase.pas
@@ -87,7 +87,7 @@ type
     destructor Destroy; override;
   end;
 
-implementation
+implementation /// \cond
 
 { TdjServerBase }
 
@@ -122,5 +122,5 @@ begin
   inherited;
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djServerContext.pas
+++ b/source/djServerContext.pas
@@ -48,6 +48,6 @@ type
 
   TdjServerContextClass = class of TdjServerContext;
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond

--- a/source/djServerInterfaces.pas
+++ b/source/djServerInterfaces.pas
@@ -66,7 +66,7 @@ type
     property Port: Integer read GetPort write SetPort;
   end;
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond
 

--- a/source/djTypes.pas
+++ b/source/djTypes.pas
@@ -74,7 +74,7 @@ type
    *}
   TdjStringArray = array of string;
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond
 

--- a/source/djWebAppContext.pas
+++ b/source/djWebAppContext.pas
@@ -49,6 +49,6 @@ type
     // pas2dox requires the class declaration to use the end; statement
   end;
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond

--- a/source/djWebComponentConfig.pas
+++ b/source/djWebComponentConfig.pas
@@ -43,7 +43,7 @@ type
     // pas2dox requires the class declaration to use the end; statement
   end;
 
-implementation
+implementation /// \cond
 
-end.
+end. /// \endcond
 

--- a/source/djWebComponentContextHandler.pas
+++ b/source/djWebComponentContextHandler.pas
@@ -135,7 +135,7 @@ type
       const UrlPattern: string): TdjWebFilterHolder; overload;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   Classes, SysUtils;
@@ -261,5 +261,5 @@ begin
 end;
 
 
-end.
+end. /// \endcond
 

--- a/source/djWebComponentHolders.pas
+++ b/source/djWebComponentHolders.pas
@@ -60,7 +60,7 @@ type
     function Contains(const WebComponentName: string): Boolean;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   Generics.Defaults;
@@ -87,4 +87,4 @@ begin
   end;
 end;
 
-end.
+end. /// \endcond

--- a/source/djWebComponentMapping.pas
+++ b/source/djWebComponentMapping.pas
@@ -74,7 +74,7 @@ type
     constructor Create;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   Generics.Defaults;
@@ -100,5 +100,5 @@ begin
   inherited;
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djWebFilter.pas
+++ b/source/djWebFilter.pas
@@ -58,7 +58,7 @@ type
    *}
   TdjWebFilterClass = class of TdjWebFilter;
 
-implementation
+implementation /// \cond
 
 { TdjWebFilter }
 
@@ -71,5 +71,5 @@ begin
   {$ENDIF DARAJA_LOGGING}
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djWebFilterChain.pas
+++ b/source/djWebFilterChain.pas
@@ -65,7 +65,7 @@ type
     constructor Create(Holder: TdjWebFilterHolder; const FilterChain: IWebFilterChain);
   end;
 
-implementation
+implementation /// \cond
 
 { TdjWebFilterChain }
 
@@ -96,5 +96,5 @@ begin
   FHolder.DoFilter(Context, Request, Response, FChain);
 end;
 
-end.
+end. /// \endcond
 

--- a/source/djWebFilterConfig.pas
+++ b/source/djWebFilterConfig.pas
@@ -47,7 +47,7 @@ type
     function GetFilterName: string;
   end;
 
-implementation
+implementation /// \cond
 
 { TdjWebFilterConfig }
 
@@ -56,6 +56,6 @@ begin
   Result := GetName;
 end;
 
-end.
+end. /// \endcond
 
 

--- a/source/djWebFilterMapping.pas
+++ b/source/djWebFilterMapping.pas
@@ -78,7 +78,7 @@ type
     constructor Create;
   end;
 
-implementation
+implementation /// \cond
 
 uses
   djPathMap,
@@ -124,5 +124,5 @@ begin
   end;
 end;
 
-end.
+end. /// \endcond
 


### PR DESCRIPTION
A review of the repository documentation against the current code turned up
several statements that no longer hold. One of them was worth fixing in the
code rather than in the prose; the rest are corrections.

### Fence off the implementation section in every source unit

`DOC-COMMENTS.md` states that every unit hides its implementation section from
the generated API docs with `implementation /// \cond` … `end. /// \endcond`.
Only 12 of the 40 units in `source/` did. The remaining 28 now follow the
convention, so the documented rule is true and whether an implementation symbol
reaches the site no longer depends on which unit it lives in.

Comment-only change. The FPC suite passes: 79 tests, 0 errors, 0 failures.

### DOC-COMMENTS.md

- The `/// \private` example named `TdjLifeCycle`, which carries no such marker.
  The markers are on the `DoStart` / `DoStop` overrides in `TdjServer`,
  `TdjAbstractHandler`, `TdjHandlerCollection`, `TdjHTTPConnector` and
  `TdjWebComponentHolder`.
- The "commands in use" table claimed to be the complete vocabulary but omitted
  `@class` (`djTypes`), `@implements` (`djAbstractConfig`, `djContextHandler`)
  and `@tparam` (`djGenericHolder`).

### UNIT-TESTS.md

- The CI section said the workflow runs "on every push and pull request that
  touches `source/` or `test/`". The push trigger is limited to `master`; pull
  requests also trigger on the workflow file, and `workflow_dispatch` exists.
  The Windows job's Lazarus version (`setup-lazarus` `stable`) is now named.
- The `--opt` note read as a standing limitation. It was Lazarus 3.0's
  `lazbuild` that rejected the flag; the `ConsoleCI` build mode is kept because
  it works on either.

### README / demo

- The feature list presented static content on the same footing as the core
  features, but `TdjDefaultWebComponent` lives in `source/optional/` and its own
  doc comment calls it unsupported demonstration code. The bullet now names the
  class, and a note under the list covers it and the helper filters.
- `demo/readme.md`: "one ore more" → "one or more".

Not addressed: the getting-started PDF link points at 3.1.0 while the version
constant is `3.2.0-SNAPSHOT`. It is labelled with its version, so it is only
stale once a 3.2 PDF is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
