### PR TITLE
djServer: consistent connector errors, RemoveConnector, GetConnector (#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,19 @@ _Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraj
   path are resolved and the result is verified to stay inside the static
   content directory, otherwise a 404 is returned. (#419)
 
+### Added
+
+- `TdjServer.RemoveConnector` removes a previously added connector (stopping it
+  first if the server is running), and `TdjServer.GetConnector(Index)` returns
+  the connector at a position so the connectors can be enumerated together with
+  `ConnectorCount`. (#433)
+
 ### Changed
 
+- `TdjServer.AddConnector`: adding a second connector for a `host:port` that is
+  already registered now raises `EWebComponentException` with a clear message
+  instead of letting a raw `EListError` escape, matching `TdjServer.Add`
+  (context) and the web-filter name check. (#433)
 - `TdjWebComponent.Service`: an unrecognised HTTP method now responds
   `501 Not Implemented` instead of falling through to 404. (#423)
 - `TdjPathMap`: a prefix pattern `/foo/*` now also matches the bare path

--- a/source/djServer.pas
+++ b/source/djServer.pas
@@ -185,6 +185,8 @@ type
      * released when the server is destroyed. Do not free it yourself.
      *
      * @param Connector the connector
+     * @throws EWebComponentException if a connector for the same host and port
+     *   is already registered.
      *}
     procedure AddConnector(const Connector: IConnector); overload;
 
@@ -193,8 +195,30 @@ type
      *
      * @param Host the connector host name
      * @param Port the connector port number
+     * @throws EWebComponentException if a connector for the same host and port
+     *   is already registered.
      *}
     procedure AddConnector(const Host: string; Port: Integer = DEFAULT_BINDING_PORT); overload;
+
+    {*
+     * Remove a previously added connector.
+     *
+     * If the server is started, the connector is stopped before it is removed.
+     *
+     * @param Connector the connector to remove
+     * @throws EWebComponentException if the connector is not registered.
+     *}
+    procedure RemoveConnector(const Connector: IConnector);
+
+    {*
+     * The connector at the given position, in the order the connectors were
+     * added. Use together with ConnectorCount to enumerate the connectors.
+     *
+     * @param Index zero-based position, 0 <= Index < ConnectorCount
+     * @returns the connector
+     * @throws EWebComponentException if Index is out of range.
+     *}
+    function GetConnector(Index: Integer): IConnector;
 
     {*
      * Add a new context.
@@ -289,6 +313,12 @@ var
 begin
   ConnectorName := '[' + Connector.Host + ']:' + IntToStr(Connector.Port);
 
+  if ConnectorMap.ContainsKey(ConnectorName) then
+  begin
+    raise EWebComponentException.CreateFmt(
+      'A connector for "%s" is already registered.', [ConnectorName]);
+  end;
+
   ConnectorMap.Add(ConnectorName, Connector);
   ConnectorList.Add(ConnectorName);
 
@@ -296,6 +326,38 @@ begin
   begin
     Connector.Start;
   end;
+end;
+
+procedure TdjServer.RemoveConnector(const Connector: IConnector);
+var
+  ConnectorName: string;
+begin
+  ConnectorName := '[' + Connector.Host + ']:' + IntToStr(Connector.Port);
+
+  if not ConnectorMap.ContainsKey(ConnectorName) then
+  begin
+    raise EWebComponentException.CreateFmt(
+      'No connector for "%s" is registered.', [ConnectorName]);
+  end;
+
+  if IsStarted then
+  begin
+    Connector.Stop;
+  end;
+
+  ConnectorList.Delete(ConnectorList.IndexOf(ConnectorName));
+  ConnectorMap.Remove(ConnectorName);
+end;
+
+function TdjServer.GetConnector(Index: Integer): IConnector;
+begin
+  if (Index < 0) or (Index >= ConnectorList.Count) then
+  begin
+    raise EWebComponentException.CreateFmt(
+      'Connector index %d out of range (0..%d).', [Index, ConnectorList.Count - 1]);
+  end;
+
+  Result := ConnectorMap[ConnectorList[Index]];
 end;
 
 procedure TdjServer.AddConnector(const Host: string; Port: Integer =

--- a/test/unittests/ConfigAPITests.pas
+++ b/test/unittests/ConfigAPITests.pas
@@ -99,6 +99,10 @@ type
     procedure TestIPv6ConnectionToLoopback;
 
     procedure TestAddConnector;
+    procedure TestAddDuplicateConnectorRaisesException;
+    procedure TestRemoveConnector;
+    procedure TestRemoveUnknownConnectorRaisesException;
+    procedure TestEnumerateConnectors;
     procedure TestThreadPool;
 
     procedure TestBindErrorRaisesException;
@@ -136,7 +140,7 @@ implementation
 uses
   djWebAppContext, djInterfaces, djWebComponent, djWebComponentHolder,
   djWebComponentContextHandler, djServer, djDefaultHandler,
-  djHTTPConnector, djContextHandlerCollection, djHandlerList, djTypes,
+  djHTTPConnector, djServerInterfaces, djContextHandlerCollection, djHandlerList, djTypes,
   djAbstractHandler, djServerContext, djWebFilter, djWebFilterHolder,
   djWebFilterConfig,
   {$IFDEF FPC}{$NOTES OFF}{$ENDIF}{$HINTS OFF}{$WARNINGS OFF}
@@ -881,6 +885,96 @@ begin
     end;
   finally
     Intercept.Free
+  end;
+end;
+
+procedure TAPIConfigTests.TestAddDuplicateConnectorRaisesException;
+var
+  Server: TdjServer;
+begin
+  Server := TdjServer.Create;
+  try
+    Server.AddConnector('127.0.0.1', 8080);
+
+    {$IFDEF FPC}
+    ExpectException(EWebComponentException, '');
+    {$ELSE}
+    ExpectedException := EWebComponentException;
+    {$ENDIF}
+    Server.AddConnector('127.0.0.1', 8080);
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TAPIConfigTests.TestRemoveConnector;
+var
+  Server: TdjServer;
+  Connector: IConnector;
+begin
+  Server := TdjServer.Create;
+  try
+    Connector := TdjHTTPConnector.Create(Server.Handler);
+    Connector.Host := '127.0.0.1';
+    Connector.Port := 8080;
+    Server.AddConnector(Connector);
+    CheckEquals(1, Server.ConnectorCount);
+
+    Server.RemoveConnector(Connector);
+    CheckEquals(0, Server.ConnectorCount);
+
+    // removable and re-addable
+    Server.AddConnector(Connector);
+    CheckEquals(1, Server.ConnectorCount);
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TAPIConfigTests.TestRemoveUnknownConnectorRaisesException;
+var
+  Server: TdjServer;
+  Connector: IConnector;
+begin
+  Server := TdjServer.Create;
+  try
+    Connector := TdjHTTPConnector.Create(Server.Handler);
+    Connector.Host := '127.0.0.1';
+    Connector.Port := 9999;
+
+    {$IFDEF FPC}
+    ExpectException(EWebComponentException, '');
+    {$ELSE}
+    ExpectedException := EWebComponentException;
+    {$ENDIF}
+    Server.RemoveConnector(Connector);
+  finally
+    Server.Free;
+  end;
+end;
+
+procedure TAPIConfigTests.TestEnumerateConnectors;
+var
+  Server: TdjServer;
+  I: Integer;
+  Ports: string;
+begin
+  Server := TdjServer.Create;
+  try
+    Server.AddConnector('127.0.0.1', 8181);
+    Server.AddConnector('127.0.0.1', 8080);
+    Server.AddConnector('127.0.0.1', 8282);
+
+    CheckEquals(3, Server.ConnectorCount);
+
+    Ports := '';
+    for I := 0 to Server.ConnectorCount - 1 do
+      Ports := Ports + IntToStr(Server.GetConnector(I).Port) + ' ';
+
+    // preserves insertion order
+    CheckEquals('8181 8080 8282 ', Ports);
+  finally
+    Server.Free;
   end;
 end;
 


### PR DESCRIPTION
Closes #433.

## Changes

**`source/djServer.pas`**
- `AddConnector` now raises `EWebComponentException` with a clear message when a connector for the same `host:port` is already registered, instead of letting a raw `EListError` escape. This matches `TdjServer.Add` (context) and the web-filter name check.
- New `RemoveConnector(const Connector: IConnector)` — stops the connector first if the server is running, then removes it; raises `EWebComponentException` if it is not registered.
- New `GetConnector(Index: Integer): IConnector` — returns the connector at a position in insertion order, so connectors can be enumerated together with `ConnectorCount`. Range-checked.
- Doc comments updated for all three.

**`test/unittests/ConfigAPITests.pas`**
- Added `TestAddDuplicateConnectorRaisesException`, `TestRemoveConnector`, `TestRemoveUnknownConnectorRaisesException`, `TestEnumerateConnectors`.

**`CHANGELOG.md`**
- Added/Changed entries under the 3.2.0 Unreleased section.

## Testing

- FPC: `run-fpc.sh` — 83 tests, 0 failures
- Delphi: `run-delphi.cmd` — 83 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)