### PR TITLE
djWebComponent: derive HEAD from the GET handler (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ _Work tracked under the [3.2.0 milestone](https://github.com/michaelJustin/daraj
   responses therefore gain conditional GET (`304 Not Modified`),
   `Last-Modified` and the OS file-transfer fast path, and still render in the
   browser rather than being offered as a download. (#466)
+- `TdjWebComponent.OnHead` is derived from the GET handler instead of always
+  responding `405 Method Not Allowed`. A component which overrides `OnGet` now
+  answers `HEAD` requests with the GET headers — including the `Content-Length`
+  the GET would have produced and the `OnGetLastModified` conditional handling
+  — and no body. A component which overrides neither still returns 405. Note
+  that the GET handler runs in full for a `HEAD` request, so its cost and any
+  side effects apply; override `OnHead` to handle `HEAD` separately. (#428)
 - `TdjWebComponent.Service`: an unrecognised HTTP method now responds
   `501 Not Implemented` instead of falling through to 404. (#423)
 - `TdjPathMap`: a prefix pattern `/foo/*` now also matches the bare path

--- a/source/djWebComponent.pas
+++ b/source/djWebComponent.pas
@@ -52,8 +52,8 @@ type
    *
    * @note Method handling notes and current limitations:
    * @li every On* handler that is not overridden responds with 405 Method Not
-   *     Allowed. In particular HEAD and OPTIONS are not derived from OnGet -
-   *     override OnHead / OnOptions explicitly if you need them.
+   *     Allowed, with one exception: HEAD is derived from OnGet (see OnHead).
+   *     OPTIONS is not derived - override OnOptions explicitly if you need it.
    * @li an unrecognised HTTP method responds with 501 Not Implemented.
    * @li conditional GET is supported through OnGetLastModified only
    *     (If-Modified-Since); there is no ETag / If-None-Match handling.
@@ -65,6 +65,8 @@ type
     {$ENDIF DARAJA_LOGGING}
 
     procedure DoCachedGet(Request: TdjRequest; Response: TdjResponse); virtual;
+
+    procedure SetHeadContentLength(Response: TdjResponse);
   protected
     {*
      * Called by the server to handle a DELETE request.
@@ -82,6 +84,20 @@ type
 
     {*
      * Called by the server (via the service method) to allow a component to handle a HEAD request.
+     *
+     * The default implementation runs the same code path as a GET request,
+     * including the OnGetLastModified conditional handling, and the response
+     * body is suppressed. A component which overrides OnGet therefore answers
+     * HEAD requests with the GET headers and no content. If OnGet is not
+     * overridden either, the response is 405 Method Not Allowed.
+     *
+     * @note because the GET path runs in full, an expensive OnGet does its work
+     * for a HEAD request too, and any side effect of OnGet is triggered by a
+     * HEAD request as well. Override this method to handle HEAD separately.
+     *
+     * @param Request The HTTP request to process
+     * @param Response The HTTP response to fill
+     * @throws EWebComponentException if an exception occurs
      *}
     procedure OnHead(Request: TdjRequest; Response: TdjResponse); virtual;
 
@@ -158,7 +174,7 @@ implementation /// \cond
 
 uses
   {$IFDEF FPC}{$NOTES OFF}{$ENDIF}{$HINTS OFF}{$WARNINGS OFF}
-  IdCustomHTTPServer, IdGlobalProtocols,
+  IdCustomHTTPServer, IdGlobal, IdGlobalProtocols,
   {$IFDEF FPC}{$ELSE}{$HINTS ON}{$WARNINGS ON}{$ENDIF}
   SysUtils;
 
@@ -199,7 +215,11 @@ end;
 
 procedure TdjWebComponent.OnHead(Request: TdjRequest; Response: TdjResponse);
 begin
-  Response.ResponseNo := HTTP_ERROR_METHOD_NOT_ALLOWED;
+  // Derive HEAD from the GET path: the headers are identical, and the connector
+  // suppresses the response body of a HEAD request (Service restores the
+  // Content-Length afterwards). If OnGet is not overridden either, its default
+  // 405 response is returned unchanged.
+  DoCachedGet(Request, Response);
 end;
 
 procedure TdjWebComponent.OnOptions(Request: TdjRequest; Response: TdjResponse);
@@ -259,6 +279,48 @@ begin
   end;
 end;
 
+// The connector suppresses the body of a HEAD response, and in doing so also
+// skips its own Content-Length calculation, leaving "Content-Length: 0". This
+// restores the length that the same response would have carried as a GET,
+// mirroring the calculation in TIdHTTPResponseInfo.WriteHeader.
+procedure TdjWebComponent.SetHeadContentLength(Response: TdjResponse);
+var
+  LCharSet: string;
+begin
+  // the handler has set a length itself
+  if Response.ContentLength <> -1 then Exit;
+
+  // a non-identity transfer coding must not be sent with a Content-Length
+  if (Response.TransferEncoding <> '')
+    and not SameText(Response.TransferEncoding, 'identity') then Exit;
+
+  // responses which never carry a body
+  if ((Response.ResponseNo div 100) = 1)
+    or (Response.ResponseNo = 204)
+    or (Response.ResponseNo = 304) then Exit;
+
+  if Response.ContentText <> '' then
+  begin
+    LCharSet := Response.CharSet;
+    if LCharSet = '' then
+    begin
+      // no content type was set, so the connector falls back to its default
+      if SizeOf(Char) > 1 then
+      begin
+        LCharSet := 'utf-8';
+      end else begin
+        LCharSet := 'ISO-8859-1';
+      end;
+    end;
+    Response.ContentLength :=
+      CharsetToEncoding(LCharSet).GetByteCount(Response.ContentText);
+  end
+  else if Assigned(Response.ContentStream) then
+  begin
+    Response.ContentLength := Response.ContentStream.Size;
+  end;
+end;
+
 procedure TdjWebComponent.Service(Context: TdjServerContext;
   Request: TdjRequest; Response: TdjResponse);
 begin
@@ -266,6 +328,7 @@ begin
     hcHEAD:
       begin
         OnHead(Request, Response);
+        SetHeadContentLength(Response);
       end;
     hcGET:
       begin

--- a/test/unittests/ConfigAPITests.pas
+++ b/test/unittests/ConfigAPITests.pas
@@ -111,6 +111,11 @@ type
     // (since 1.2.10)
     procedure TestCachedGetRequest;
 
+    // test that HEAD is derived from the GET handler (issue #428)
+    procedure TestHeadRequestUsesGetHandler;
+    procedure TestHeadRequestWithoutGetHandlerReturns405;
+    procedure TestCachedHeadRequest;
+
     procedure TestOnlyAFilter;
     procedure TestFilter;
     procedure TestTwoFilters;
@@ -1168,6 +1173,67 @@ begin
 
     // set "If-Modified-Since" header to Now to get "304 resource not modified"
     CheckCachedGETResponseIs304(Now, '/cached/index.html');
+
+  finally
+    Server.Free;
+  end;
+end;
+
+// a component which overrides OnGet only must answer HEAD requests with the
+// GET headers and no body (issue #428)
+procedure TAPIConfigTests.TestHeadRequestUsesGetHandler;
+var
+  Server: TdjServer;
+  Context: TdjWebAppContext;
+begin
+  Server := TdjServer.Create;
+  try
+    Context := TdjWebAppContext.Create('get');
+    Context.Add(TGetComponent, '/hello');
+    Server.Add(Context);
+    Server.Start;
+
+    CheckHEADMatchesGET('/get/hello');
+
+  finally
+    Server.Free;
+  end;
+end;
+
+// if OnGet is not overridden either, HEAD still returns 405 (issue #428)
+procedure TAPIConfigTests.TestHeadRequestWithoutGetHandlerReturns405;
+var
+  Server: TdjServer;
+  Context: TdjWebAppContext;
+begin
+  Server := TdjServer.Create;
+  try
+    Context := TdjWebAppContext.Create('get');
+    Context.Add(TNoMethodComponent, '/hello');
+    Server.Add(Context);
+    Server.Start;
+
+    CheckHEADResponse405('/get/hello');
+
+  finally
+    Server.Free;
+  end;
+end;
+
+// HEAD runs the cached GET path, so it honors If-Modified-Since (issue #428)
+procedure TAPIConfigTests.TestCachedHeadRequest;
+var
+  Server: TdjServer;
+  Context: TdjWebAppContext;
+begin
+  Server := TdjServer.Create;
+  try
+    Context := TdjWebAppContext.Create('cached');
+    Context.Add(TCachedGetComponent, '*.html');
+    Server.Add(Context);
+    Server.Start;
+
+    CheckCachedHEADResponseIs304(Now, '/cached/index.html');
 
   finally
     Server.Free;

--- a/test/unittests/HTTPTestCase.pas
+++ b/test/unittests/HTTPTestCase.pas
@@ -79,6 +79,16 @@ type
     // header as If-Modified-Since; checks that the second response is 304.
     procedure CheckConditionalGETIs304(URL: string = ''; msg: string = '');
 
+    // GET the URL, then send a HEAD request for it; checks that HEAD answers
+    // 200 with the same Content-Length and Content-Type as the GET, and that
+    // no response body is sent.
+    procedure CheckHEADMatchesGET(URL: string = ''; msg: string = '');
+
+    procedure CheckHEADResponse405(URL: string = ''; msg: string = '');
+
+    // send a HEAD request with an If-Modified-Since header; checks for 304.
+    procedure CheckCachedHEADResponseIs304(IfModifiedSince: TDateTime; URL: string = ''; msg: string = '');
+
     procedure CheckContentTypeEquals(Expected: string; URL: string = ''; msg: string = '');
 
     // GET the URL and compare a single response header value.
@@ -150,6 +160,54 @@ begin
   IdHTTP.HTTPOptions := IdHTTP.HTTPOptions + [hoNoProtocolErrorException];
 
   IdHTTP.Get(URL);
+  CheckEquals(304, IdHTTP.ResponseCode, msg);
+end;
+
+procedure THTTPTestCase.CheckHEADMatchesGET(URL: string = ''; msg: string = '');
+var
+  Body: string;
+  GetLength: Integer;
+  GetContentType: string;
+begin
+  if Pos('http', URL) <> 1 then URL := StrHttp127001 + URL;
+
+  Body := IdHTTP.Get(URL);
+  GetLength := IdHTTP.Response.ContentLength;
+  GetContentType := IdHTTP.Response.ContentType;
+
+  IdHTTP.Head(URL);
+
+  CheckEquals(200, IdHTTP.ResponseCode, msg);
+  CheckEquals(GetLength, Integer(IdHTTP.Response.ContentLength),
+    'HEAD Content-Length differs from GET');
+  CheckEquals(GetContentType, IdHTTP.Response.ContentType,
+    'HEAD Content-Type differs from GET');
+
+  // a body sent in response to HEAD would still be in the connection buffer
+  // and would desynchronize this follow-up request on the same connection
+  CheckEquals(Body, IdHTTP.Get(URL), 'a response body was sent for HEAD');
+end;
+
+procedure THTTPTestCase.CheckHEADResponse405(URL: string = ''; msg: string = '');
+begin
+  if Pos('http', URL) <> 1 then URL := StrHttp127001 + URL;
+
+  // TIdHTTP.Head has no "allowed response codes" parameter
+  IdHTTP.HTTPOptions := IdHTTP.HTTPOptions + [hoNoProtocolErrorException];
+
+  IdHTTP.Head(URL);
+  CheckEquals(405, IdHTTP.ResponseCode, msg);
+end;
+
+procedure THTTPTestCase.CheckCachedHEADResponseIs304(IfModifiedSince: TDateTime;
+  URL: string = ''; msg: string = '');
+begin
+  if Pos('http', URL) <> 1 then URL := StrHttp127001 + URL;
+
+  IdHTTP.Request.LastModified := IfModifiedSince;
+  IdHTTP.HTTPOptions := IdHTTP.HTTPOptions + [hoNoProtocolErrorException];
+
+  IdHTTP.Head(URL);
   CheckEquals(304, IdHTTP.ResponseCode, msg);
 end;
 


### PR DESCRIPTION
Closes #428.

`TdjWebComponent.OnHead` defaulted to 405 independently of `OnGet`, so every component that overrides only `OnGet` answered `HEAD` with 405. That breaks health checks, link checkers, caching proxies and any client that probes a resource before fetching it.

## Change

- The default `OnHead` now runs `DoCachedGet`, so `HEAD` returns the GET headers — including the `OnGetLastModified` conditional handling — and no body.
- If `OnGet` is not overridden either, its own 405 default is returned unchanged, so a component that handles neither method still reports 405. No override detection is needed.
- `Service` restores the `Content-Length` for HEAD responses. Indy suppresses the body of a HEAD response but in doing so also skips its own `Content-Length` calculation and emits `Content-Length: 0`; the new `SetHeadContentLength` mirrors the calculation in `TIdHTTPResponseInfo.WriteHeader`, and leaves the header alone when the handler set a length itself, when a non-identity transfer coding is in use, or on a status that never carries a body (1xx/204/304).

`OPTIONS` is deliberately left alone — that is #429.

## Notes for reviewers

This is a behaviour change, recorded under `### Changed` in the CHANGELOG: `HEAD` on a component with an `OnGet` goes from 405 to 200. The GET handler now runs in full for a `HEAD` request, so its cost and any side effects apply; the `OnHead` doc comment says so and points at overriding `OnHead` to handle `HEAD` separately.

No `OnHead` override existed anywhere in `source/`, `demo/` or `test/`, and no test asserted the old behaviour.

## Tests

Three tests added to `TAPIConfigTests`, with matching helpers in `THTTPTestCase`:

- `TestHeadRequestUsesGetHandler` — HEAD on a GET-only component returns 200 with the same `Content-Length` and `Content-Type` as the GET, and no body. The no-body check reissues the GET on the same keep-alive connection: a stray body would desynchronize it.
- `TestHeadRequestWithoutGetHandlerReturns405` — a component overriding nothing still returns 405.
- `TestCachedHeadRequest` — HEAD honours `If-Modified-Since` and returns 304.

Both suites pass: FPC 86 tests, Delphi 86 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)