### PR TITLE
docs: point Getting Started PDF links at the repo copy

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -173,7 +173,7 @@ Hello, World!
 
 ### Getting started with Daraja
 
-[DarajaFrameworkGettingStarted.pdf](https://www.habarisoft.com/daraja_framework/3.1.0/DarajaFrameworkGettingStarted.pdf) (version 3.1.0)
+[DarajaFrameworkGettingStarted.pdf](https://github.com/michaelJustin/daraja-framework/blob/master/docs/DarajaFrameworkGettingStarted.pdf)
 
 ### Changelog
 

--- a/source/djServer.pas
+++ b/source/djServer.pas
@@ -102,7 +102,7 @@ const
    * @section documentation Documentation
    *
    * @li This site is the API reference, generated from the doc comments in the source folder.
-   * @li A getting started guide is available at <a target="_blank" href="https://www.habarisoft.com/daraja_framework/3.1.0/DarajaFrameworkGettingStarted.pdf">DarajaFrameworkGettingStarted.pdf</a>.
+   * @li A getting started guide is available at <a target="_blank" href="https://github.com/michaelJustin/daraja-framework/blob/master/docs/DarajaFrameworkGettingStarted.pdf">DarajaFrameworkGettingStarted.pdf</a>.
    * @li The project README, on <a target="_blank" href="https://github.com/michaelJustin/daraja-framework">GitHub</a>, covers installation, dependencies and the release changelog.
    *
    * @section licensing Licensing


### PR DESCRIPTION
The README and the `TdjServer` doc-comment linked to
`https://www.habarisoft.com/daraja_framework/3.1.0/DarajaFrameworkGettingStarted.pdf`,
which is both stale (3.1.0) and an external mirror.

Both now point at the tracked copy:
`https://github.com/michaelJustin/daraja-framework/blob/master/docs/DarajaFrameworkGettingStarted.pdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)