### PR TITLE
djWebComponent: drop dead virtual on strict private DoCachedGet

### DIFF
--- a/source/djWebComponent.pas
+++ b/source/djWebComponent.pas
@@ -64,7 +64,7 @@ type
     Logger: ILogger;
     {$ENDIF DARAJA_LOGGING}
 
-    procedure DoCachedGet(Request: TdjRequest; Response: TdjResponse); virtual;
+    procedure DoCachedGet(Request: TdjRequest; Response: TdjResponse);
 
     procedure SetHeadContentLength(Response: TdjResponse);
   protected


### PR DESCRIPTION
\`DoCachedGet\` is declared \`strict private\`, so no descendant can ever override it — \`virtual\` was dead weight, most likely left over from an earlier design where the method was \`protected\`. Dropping the modifier is behaviorally a no-op: dispatch was already static everywhere outside the declaring unit.

Flagged as an aside while working on #428, not tied to any open issue.

Both suites pass: FPC 86 tests, Delphi 86 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)