### PR TITLE
Bump version to 3.2.1-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Releases are tagged `vMAJOR.MINOR.PATCH` and published at
 
 ## [Unreleased]
 
+### Internal
+
+- Version constant set to `3.2.1-SNAPSHOT`.
+
 ## [3.2.0] - 2026-09-09
 
 ### Security

--- a/source/djGlobal.pas
+++ b/source/djGlobal.pas
@@ -31,7 +31,7 @@ unit djGlobal;
 interface
 
 const
-  DWF_SERVER_VERSION = '3.2.0';
+  DWF_SERVER_VERSION = '3.2.1-SNAPSHOT';
   DWF_SERVER_FULL_NAME = 'Daraja HTTP Framework ' + DWF_SERVER_VERSION;
   DWF_SERVER_COPYRIGHT = 'Copyright (c) 2016 Michael Justin';
 


### PR DESCRIPTION
Post-release housekeeping: 3.2.0 is tagged and published, so `master` moves to the next snapshot.

- **djGlobal**: `DWF_SERVER_VERSION` `3.2.0` -> `3.2.1-SNAPSHOT`.
- **CHANGELOG**: note the constant change under `[Unreleased]` / Internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)