### PR TITLE
doxygen: stop exposing strict-private fields as public attributes

### DIFF
--- a/make/doxygen-filter.ps1
+++ b/make/doxygen-filter.ps1
@@ -1,0 +1,31 @@
+<#
+  Doxygen FILTER_PATTERNS script for *.pas files.
+
+  Runs pas2dox (which turns the Pascal source into the C++-ish form Doxygen
+  parses), but first rewrites Delphi's "strict private" / "strict protected"
+  to plain "private" / "protected".
+
+  pas2dox does not translate the "strict" visibility specifiers: it emits the
+  members under the class's leading "public:" section, so every strict-private
+  backing field (FStarted, FContext, CS, ...) ends up documented as a public
+  attribute. Downgrading them to the non-strict specifiers lets pas2dox map
+  them to "private:" / "protected:", which EXTRACT_PRIVATE = NO then hides.
+#>
+param([Parameter(Mandatory = $true)][string]$Path)
+
+$ErrorActionPreference = 'Stop'
+$pas2dox = Join-Path $PSScriptRoot 'pas2dox-0.50rc1.exe'
+
+$source = Get-Content -Raw -LiteralPath $Path
+$source = $source -replace '(?im)^([ \t]*)strict[ \t]+private\b',   '$1private'
+$source = $source -replace '(?im)^([ \t]*)strict[ \t]+protected\b', '$1protected'
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("djdox_" + [System.Guid]::NewGuid().ToString("N") + ".pas")
+try {
+    [System.IO.File]::WriteAllText($tmp, $source, (New-Object System.Text.UTF8Encoding($false)))
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+    & $pas2dox -s $tmp
+}
+finally {
+    Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
+}

--- a/make/doxygen.cfg
+++ b/make/doxygen.cfg
@@ -1163,7 +1163,10 @@ INPUT_FILTER           =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by Doxygen.
 
-FILTER_PATTERNS        = "*.pas=make\pas2dox-0.50rc1 -s"
+# doxygen-filter.ps1 rewrites "strict private/protected" to the non-strict
+# specifiers (pas2dox would otherwise expose strict-private fields as public),
+# then runs pas2dox -s itself.
+FILTER_PATTERNS        = "*.pas=powershell -NoProfile -ExecutionPolicy Bypass -File make/doxygen-filter.ps1"
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for


### PR DESCRIPTION
## Problem

The Doxygen API docs list `strict private` members as **public** — e.g. `TdjLifeCycle` shows `CS` and `FStopped` under "Public Attributes", and the same leak affects ~40 backing fields across `TdjServer`, `TdjWebComponentHandler`, `TdjContextHandler`, `TdjAbstractConnector`, `TdjWebFilterHolder`, and others.

Root cause is **pas2dox**, not Doxygen: `.pas` files are run through `FILTER_PATTERNS = "*.pas=make\pas2dox-0.50rc1 -s"`, and pas2dox does not translate Delphi's `strict private` / `strict protected` — it drops the specifier, so the members fall under the class's leading `public:` section and Doxygen documents them as public attributes. (This is why `INPUT_FILTER` and `/// \private` tags have no effect on the field list — `FILTER_PATTERNS` takes precedence and pas2dox runs unmodified.)

## Fix

- Add `make/doxygen-filter.ps1`, which rewrites `strict private` → `private` and `strict protected` → `protected` before running `pas2dox-0.50rc1.exe -s` itself.
- Point `FILTER_PATTERNS` at the wrapper instead of calling pas2dox directly.

pas2dox maps plain `private:` / `protected:` correctly, so `EXTRACT_PRIVATE = NO` then hides them. Pure PowerShell — no `sed` — so it runs on the `windows-latest` CI runner and locally.

## Verification

Full scratch rebuild: `doxygen` exits 0, no new warnings (only the 2 pre-existing "recursive class relation" ones).

- `TdjLifeCycle` "Public Attributes" → now just `Started` / `Stopped` (the real public properties).
- All leaked `F*` fields removed framework-wide.
- Public/protected API intact: 73 class pages before and after; public constructors, `AddConnector` / `GetConnector` / `RemoveConnector`, and `protected` methods all still documented.

Trade-off: doc build is a little slower (~44s) because PowerShell spawns once per `.pas` file.

Regenerated `docs/html/` is intentionally not included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)