### PR TITLE
Prefix strict-private fields with F

### DIFF
--- a/source/djHTTPConnector.pas
+++ b/source/djHTTPConnector.pas
@@ -52,7 +52,7 @@ type
     Logger: ILogger;
     {$ENDIF DARAJA_LOGGING}
     FHTTPServer: TdjHTTPServer;
-    HostAndPort: string;
+    FHostAndPort: string;
     procedure OnCommand(AContext: TIdContext;
       ARequestInfo: TdjRequest; AResponseInfo: TdjResponse);
   protected
@@ -142,7 +142,7 @@ begin
   Logger.Trace('Starting Indy HTTP server');
   {$ENDIF DARAJA_LOGGING}
 
-  HostAndPort := 'http://' + Host + ':' + IntToStr(Port);
+  FHostAndPort := 'http://' + Host + ':' + IntToStr(Port);
 
   try
     // command handler
@@ -154,14 +154,14 @@ begin
     // TdjLifeCycle.Start sets the started flag once DoStart returns.
 
     {$IFDEF DARAJA_LOGGING}
-    Logger.Info('Accepting requests at %s', [HostAndPort]);
+    Logger.Info('Accepting requests at %s', [FHostAndPort]);
     {$ENDIF DARAJA_LOGGING}
 
   except
     on E: Exception do
     begin
       {$IFDEF DARAJA_LOGGING}
-      Logger.Info('Could not start HTTP connector at %s', [HostAndPort]);
+      Logger.Info('Could not start HTTP connector at %s', [FHostAndPort]);
       Logger.Error(E.Message, E);
       {$ENDIF DARAJA_LOGGING}
       raise;
@@ -174,7 +174,7 @@ begin
   if IsStarted then
   begin
     {$IFDEF DARAJA_LOGGING}
-    Logger.Trace('Stopping HTTP connector at %s', [HostAndPort]);
+    Logger.Trace('Stopping HTTP connector at %s', [FHostAndPort]);
     {$ENDIF DARAJA_LOGGING}
 
     try

--- a/source/djLifeCycle.pas
+++ b/source/djLifeCycle.pas
@@ -47,7 +47,7 @@ type
   strict private
     FStarted: Boolean;
     FStopped: Boolean;
-    CS: TCriticalSection;
+    FCS: TCriticalSection;
     {$IFDEF DARAJA_LOGGING}
     Logger: ILogger;
     {$ENDIF DARAJA_LOGGING}
@@ -115,14 +115,14 @@ begin
   Logger := TdjLoggerFactory.GetLogger(TdjLifeCycle);
   {$ENDIF DARAJA_LOGGING}
 
-  CS := TCriticalSection.Create;
+  FCS := TCriticalSection.Create;
 
   FStopped := True;
 end;
 
 destructor TdjLifeCycle.Destroy;
 begin
-  CS.Free;
+  FCS.Free;
 
   inherited;
 end;
@@ -156,7 +156,7 @@ begin
   if IsStarted then
     Exit;
 
-  CS.Enter;
+  FCS.Enter;
   try
     try
       DoStart;
@@ -173,7 +173,7 @@ begin
       end;
     end;
   finally
-    CS.Leave;
+    FCS.Leave;
   end;
 end;
 
@@ -182,7 +182,7 @@ begin
   if Stopped then
     Exit;
 
-  CS.Enter;
+  FCS.Enter;
   try
     try
       DoStop;
@@ -200,7 +200,7 @@ begin
     FStopped := True;
     FStarted := False;
   finally
-    CS.Leave;
+    FCS.Leave;
   end;
 end;
 

--- a/source/djServer.pas
+++ b/source/djServer.pas
@@ -138,10 +138,10 @@ type
     {$ENDIF DARAJA_LOGGING}
     FDefaultHost: string;
     FDefaultPort: Integer;
-    ConnectorMap: TObjectDictionary<string, IConnector>;
-    ConnectorList: TdjStrings;
-    ContextHandlers: IHandlerContainer;
-    ContextNames: TStrings;
+    FConnectorMap: TObjectDictionary<string, IConnector>;
+    FConnectorList: TdjStrings;
+    FContextHandlers: IHandlerContainer;
+    FContextNames: TStrings;
     procedure StartConnectors;
     procedure StopConnectors;
     procedure StopContextHandlers;
@@ -261,14 +261,14 @@ begin
   FDefaultHost := DEFAULT_BINDING_IP;
   FDefaultPort := DEFAULT_BINDING_PORT;
 
-  ConnectorMap := TObjectDictionary<string, IConnector>.Create;
+  FConnectorMap := TObjectDictionary<string, IConnector>.Create;
 
-  ConnectorList := TdjStrings.Create;
+  FConnectorList := TdjStrings.Create;
 
-  ContextHandlers := TdjContextHandlerCollection.Create;
-  ContextNames := TStringList.Create;
+  FContextHandlers := TdjContextHandlerCollection.Create;
+  FContextNames := TStringList.Create;
 
-  AddHandler(ContextHandlers);
+  AddHandler(FContextHandlers);
 end;
 
 constructor TdjServer.Create(const AHost: string;
@@ -294,17 +294,17 @@ begin
     Stop;
   end;
 
-  ConnectorMap.Free;
-  ConnectorList.Free;
+  FConnectorMap.Free;
+  FConnectorList.Free;
 
-  ContextNames.Free;
+  FContextNames.Free;
 
   inherited;
 end;
 
 function TdjServer.ConnectorCount: Integer;
 begin
-  Result := ConnectorList.Count;
+  Result := FConnectorList.Count;
 end;
 
 procedure TdjServer.AddConnector(const Connector: IConnector);
@@ -313,14 +313,14 @@ var
 begin
   ConnectorName := '[' + Connector.Host + ']:' + IntToStr(Connector.Port);
 
-  if ConnectorMap.ContainsKey(ConnectorName) then
+  if FConnectorMap.ContainsKey(ConnectorName) then
   begin
     raise EWebComponentException.CreateFmt(
       'A connector for "%s" is already registered.', [ConnectorName]);
   end;
 
-  ConnectorMap.Add(ConnectorName, Connector);
-  ConnectorList.Add(ConnectorName);
+  FConnectorMap.Add(ConnectorName, Connector);
+  FConnectorList.Add(ConnectorName);
 
   if IsStarted then
   begin
@@ -334,7 +334,7 @@ var
 begin
   ConnectorName := '[' + Connector.Host + ']:' + IntToStr(Connector.Port);
 
-  if not ConnectorMap.ContainsKey(ConnectorName) then
+  if not FConnectorMap.ContainsKey(ConnectorName) then
   begin
     raise EWebComponentException.CreateFmt(
       'No connector for "%s" is registered.', [ConnectorName]);
@@ -345,19 +345,19 @@ begin
     Connector.Stop;
   end;
 
-  ConnectorList.Delete(ConnectorList.IndexOf(ConnectorName));
-  ConnectorMap.Remove(ConnectorName);
+  FConnectorList.Delete(FConnectorList.IndexOf(ConnectorName));
+  FConnectorMap.Remove(ConnectorName);
 end;
 
 function TdjServer.GetConnector(Index: Integer): IConnector;
 begin
-  if (Index < 0) or (Index >= ConnectorList.Count) then
+  if (Index < 0) or (Index >= FConnectorList.Count) then
   begin
     raise EWebComponentException.CreateFmt(
-      'Connector index %d out of range (0..%d).', [Index, ConnectorList.Count - 1]);
+      'Connector index %d out of range (0..%d).', [Index, FConnectorList.Count - 1]);
   end;
 
-  Result := ConnectorMap[ConnectorList[Index]];
+  Result := FConnectorMap[FConnectorList[Index]];
 end;
 
 procedure TdjServer.AddConnector(const Host: string; Port: Integer =
@@ -381,9 +381,9 @@ begin
   Logger.Trace('Add context %s', [Context.ContextPath]);
   {$ENDIF DARAJA_LOGGING}
 
-  if ContextNames.IndexOf(Context.ContextPath) < 0 then
+  if FContextNames.IndexOf(Context.ContextPath) < 0 then
   begin
-    ContextNames.Add(Context.ContextPath);
+    FContextNames.Add(Context.ContextPath);
   end else begin
     ContextPath := Context.ContextPath; // needed for exception message
     Context.Free; // avoid leak
@@ -391,7 +391,7 @@ begin
       [ContextPath]);
   end;
 
-  ContextHandlers.AddHandler(Context);
+  FContextHandlers.AddHandler(Context);
 end;
 
 procedure TdjServer.StartConnectors;
@@ -399,9 +399,9 @@ var
   ConnectorName: string;
   Connector: IConnector;
 begin
-  for ConnectorName in ConnectorList do
+  for ConnectorName in FConnectorList do
   begin
-    Connector := ConnectorMap[ConnectorName];
+    Connector := FConnectorMap[ConnectorName];
     Connector.Start;
 
     {$IFDEF DARAJA_LOGGING}
@@ -416,14 +416,14 @@ var
   Connector: IConnector;
   Keys: TdjStrings;
 begin
-  Keys := TdjStrings.Create(ConnectorList);
+  Keys := TdjStrings.Create(FConnectorList);
 
   try
     Keys.Reverse;
 
     for ConnectorName in Keys do
     begin
-      Connector := ConnectorMap[ConnectorName];
+      Connector := FConnectorMap[ConnectorName];
       Connector.Stop;
 
       {$IFDEF DARAJA_LOGGING}
@@ -438,7 +438,7 @@ end;
 
 procedure TdjServer.StopContextHandlers;
 begin
-  ContextHandlers.Stop;
+  FContextHandlers.Stop;
 end;
 
 procedure TdjServer.DoStart;
@@ -446,7 +446,7 @@ begin
   CheckNotStarted;
 
   // add default connector
-  if ConnectorList.Count = 0 then
+  if FConnectorList.Count = 0 then
   begin
     AddConnector(FDefaultHost, FDefaultPort);
   end;

--- a/source/djWebComponentContextHandler.pas
+++ b/source/djWebComponentContextHandler.pas
@@ -52,8 +52,8 @@ type
     {$IFDEF DARAJA_LOGGING}
     Logger: ILogger;
     {$ENDIF DARAJA_LOGGING}
-    WebComponentHandler: TdjWebComponentHandler;
-    AutoStartSession: Boolean;
+    FWebComponentHandler: TdjWebComponentHandler;
+    FAutoStartSession: Boolean;
   protected
     // IHandler interface
     procedure Handle(const Target: string; Context: TdjServerContext;
@@ -152,13 +152,13 @@ begin
   Logger := TdjLoggerFactory.GetLogger(TdjWebComponentContextHandler);
   {$ENDIF DARAJA_LOGGING}
 
-  Self.AutoStartSession := Sessions;
+  Self.FAutoStartSession := Sessions;
 
-  WebComponentHandler := TdjWebComponentHandler.Create;
+  FWebComponentHandler := TdjWebComponentHandler.Create;
 
-  WebComponentHandler.SetContext(Self.GetCurrentContext);
+  FWebComponentHandler.SetContext(Self.GetCurrentContext);
 
-  inherited AddHandler(WebComponentHandler);
+  inherited AddHandler(FWebComponentHandler);
 
   {$IFDEF LOG_CREATE}
   Logger.Trace('Created');
@@ -179,7 +179,7 @@ function TdjWebComponentContextHandler.AddWebComponent(ComponentClass: TdjWebCom
 var
   Holder: TdjWebComponentHolder;
 begin
-  Holder := WebComponentHandler.FindHolder(ComponentClass);
+  Holder := FWebComponentHandler.FindHolder(ComponentClass);
 
   if Holder = nil then
   begin
@@ -189,7 +189,7 @@ begin
       [ComponentClass.ClassName]);
     {$ENDIF DARAJA_LOGGING}
 
-    Holder := WebComponentHandler.AddWebComponent(ComponentClass, UrlPattern);
+    Holder := FWebComponentHandler.AddWebComponent(ComponentClass, UrlPattern);
     // set context of Holder to propagate it to WebComponentConfig
     Holder.SetContext(GetCurrentContext);
   end
@@ -201,7 +201,7 @@ begin
       [ComponentClass.ClassName, UrlPattern]);
     {$ENDIF DARAJA_LOGGING}
 
-    WebComponentHandler.AddWithMapping(Holder, UrlPattern);
+    FWebComponentHandler.AddWithMapping(Holder, UrlPattern);
   end;
 
   Result := Holder;
@@ -220,7 +220,7 @@ var
 begin
   Holder := TdjWebFilterHolder.Create(FilterClass);
   try
-    WebComponentHandler.AddWebFilter(Holder, UrlPattern);
+    FWebComponentHandler.AddWebFilter(Holder, UrlPattern);
   except
     Holder.Free;
     raise;
@@ -241,7 +241,7 @@ begin
   Logger.Trace('Context %s handles %s', [ContextPath, Target]);
   {$ENDIF DARAJA_LOGGING}
 
-  (WebComponentHandler as IHandler).Handle(Target, Context, Request, Response);
+  (FWebComponentHandler as IHandler).Handle(Target, Context, Request, Response);
 end;
 
 procedure TdjWebComponentContextHandler.Handle(const Target: string;
@@ -252,7 +252,7 @@ begin
     Exit;
   end;
 
-  if AutoStartSession then
+  if FAutoStartSession then
   begin
     GetSession(Context, Request, Response, True);
   end;

--- a/source/optional/djDefaultWebComponent.pas
+++ b/source/optional/djDefaultWebComponent.pas
@@ -67,8 +67,8 @@ type
     {$IFDEF DARAJA_LOGGING}
     Logger: ILogger;
     {$ENDIF DARAJA_LOGGING}
-    ContextPath: string;
-    StaticResourcePath: string;
+    FContextPath: string;
+    FStaticResourcePath: string;
     function BuildAbsolutePath: string;
     procedure Validate;
     {*
@@ -103,7 +103,7 @@ begin
   {$ENDIF DARAJA_LOGGING}
 
   // copy the context path
-  ContextPath := Config.GetContext.GetContextPath;
+  FContextPath := Config.GetContext.GetContextPath;
 
   // calculate the static resource path
   SetStaticResourcePath;
@@ -117,38 +117,38 @@ begin
   if DirectoryExists(BuildAbsolutePath) then
   begin
     {$IFDEF DARAJA_LOGGING}
-    Logger.Trace('Static content directory found: %s', [StaticResourcePath]);
+    Logger.Trace('Static content directory found: %s', [FStaticResourcePath]);
     {$ENDIF DARAJA_LOGGING}
   end
   else
   begin
     {$IFDEF DARAJA_LOGGING}
-    Logger.Warn('Static content directory not found: %s', [StaticResourcePath]);
+    Logger.Warn('Static content directory not found: %s', [FStaticResourcePath]);
     {$ENDIF DARAJA_LOGGING}
 
     raise EWebComponentException.CreateFmt(
       'Static resource path not found (%s)',
-      [StaticResourcePath]);
+      [FStaticResourcePath]);
   end;
 end;
 
 function TdjDefaultWebComponent.StripContext(const Doc: string): string;
 begin
-  if ContextPath = ROOT_CONTEXT then
+  if FContextPath = ROOT_CONTEXT then
     Result := Doc
   else
-    Result := Copy(Doc, Length(ContextPath) + 2, MAXINT);
+    Result := Copy(Doc, Length(FContextPath) + 2, MAXINT);
 end;
 
 procedure TdjDefaultWebComponent.SetStaticResourcePath;
 begin
-  if ContextPath = ROOT_CONTEXT then
+  if FContextPath = ROOT_CONTEXT then
   begin
-    StaticResourcePath := WEBAPPS + '/ROOT';
+    FStaticResourcePath := WEBAPPS + '/ROOT';
   end
   else
   begin
-    StaticResourcePath := WEBAPPS + '/' + ContextPath;
+    FStaticResourcePath := WEBAPPS + '/' + FContextPath;
   end;
 end;
 
@@ -222,7 +222,7 @@ end;
 
 function TdjDefaultWebComponent.BuildAbsolutePath: string;
 begin
-  Result := ExtractFilePath(ParamStr(0)) + StaticResourcePath;
+  Result := ExtractFilePath(ParamStr(0)) + FStaticResourcePath;
 end;
 
 end.


### PR DESCRIPTION
## Summary

Renames the `strict private` instance fields that did not follow the `F` naming convention. Logger fields are exempt regardless of name and left unchanged.

| File | Fields renamed |
|---|---|
| `source/djHTTPConnector.pas` | `HostAndPort` → `FHostAndPort` |
| `source/djLifeCycle.pas` | `CS` → `FCS` |
| `source/djServer.pas` | `ConnectorMap`, `ConnectorList`, `ContextHandlers`, `ContextNames` → `F…` |
| `source/djWebComponentContextHandler.pas` | `WebComponentHandler`, `AutoStartSession` → `F…` |
| `source/optional/djDefaultWebComponent.pas` | `ContextPath`, `StaticResourcePath` → `F…` |

Not touched: `Handler` in `djAbstractConnector.pas` (it is `protected`, not `strict private`), and `ContextLogger` (logger field).

## Testing

- FPC suite: 86 tests, 0 failures; heaptrace at clean baseline (6 unfreed / 744 bytes)
- Delphi suite: 86 tests, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)