### PR TITLE
ci(doxygen): cache the Chocolatey Doxygen install

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,9 +14,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Cache Doxygen install
+        id: cache-doxygen
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files\doxygen
+          key: doxygen-install-${{ runner.os }}-v1
+
       - name: Install Doxygen via Chocolatey
-        run: choco install doxygen.install -y
-        
+        if: steps.cache-doxygen.outputs.cache-hit != 'true'
+        run: choco install doxygen.install -y --no-progress
+
       - name: Add Doxygen to PATH
         run: echo "C:\\Program Files\\doxygen\\bin" >> $env:GITHUB_PATH
 


### PR DESCRIPTION
## Summary

The **Generate Doxygen Docs** workflow ran `choco install doxygen.install` on every push to `master`/tags, which is the slowest step in the job.

This adds an `actions/cache@v4` step for `C:\Program Files\doxygen` and skips the Chocolatey install on a cache hit. First run after merge populates the cache; subsequent runs restore it and go straight to doc generation.

To pick up a newer Doxygen, bump the `-v1` suffix in the cache key.

## Notes

This workflow only triggers on `push` to `master` and `v*` tags (not on PRs), so the speed-up can't be observed until it's merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)