### PR TITLE
ci: bump checkout/cache actions to Node 24 majors

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install Doxygen via Chocolatey
         run: choco install doxygen.install -y

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: Checkout daraja-framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: daraja-framework
 
       - name: Checkout Indy (dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: IndySockets/Indy
           path: Indy
 
       - name: Checkout slf4p (dependency)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: michaelJustin/slf4p
           path: slf4p
@@ -58,7 +58,7 @@ jobs:
       - name: Cache Lazarus / FPC (Windows)
         if: runner.os == 'Windows'
         id: cache-lazarus
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/installers/lazarus
           key: lazarus-${{ runner.os }}-stable-4.4-fpc-3.2.2


### PR DESCRIPTION
## What

GitHub is forcing `actions/checkout@v4` and `actions/cache@v4` onto Node 24 and warning that Node 20 is deprecated. This bumps them to the `v5` majors, which run on Node 24 natively.

- `tests.yml`: `actions/checkout@v4` → `@v5` (3 uses), `actions/cache@v4` → `@v5`
- `doxygen.yml`: stale `actions/checkout@v3` → `@v5`

Remaining Node 20 actions (`actions/upload-artifact@v4`, `peaceiris/actions-gh-pages@v3`) are third-party / have no newer major and were not flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)